### PR TITLE
Modify lumi values for 2023 and Run3

### DIFF
--- a/commonTools/commonObjects.py
+++ b/commonTools/commonObjects.py
@@ -28,13 +28,13 @@ lumiMap = {
     '2022postEE':26.70,
     '2223postEE':26.70,
     '2022': 34.7,
-    '2023preBPix': 17.8,
-    '2223preBPix': 17.8,
-    '2023postBPix': 9.5,
-    '2223postBPix': 9.5,
-    '2023': 27.3,
-    '2223': 61.9,
-    'Run3': 61.9 # Up to 2023, this does NOT include 2024.
+    '2023preBPix': 18.1,
+    '2223preBPix': 18.1,
+    '2023postBPix': 9.7,
+    '2223postBPix': 9.7,
+    '2023': 27.8,
+    '2223': 62.5,
+    'Run3': 62.5 # Up to 2023, this does NOT include 2024.
 }
 
 def CreateVariableParameters(gen_variable, reco_variable, bins, year, BMW):


### PR DESCRIPTION
This pull request updates several numerical values in the luminosity dictionary in `commonObjects.py` to reflect more accurate or recent measurements for various run periods. The changes are focused on correcting and updating the luminosity values for 2023 and combined 2022-2023 periods.

Luminosity value updates:

* Updated the luminosity values for `2023preBPix`, `2223preBPix`, `2023postBPix`, and `2223postBPix` to slightly higher numbers, reflecting new measurements.
* Increased the total luminosity values for the `2023`, `2223`, and `Run3` periods to match the updated sums.

References:
- https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVRun3Analysis#DATA_AN2
- https://cms-talk.web.cern.ch/t/luminosity-from-golden-json-for-2023/129702/4

FYI @CaioDaumann @maxwrabetz 