### PR TITLE
Read pdfindices also for impacts.

### DIFF
--- a/Combine/law_combine.py
+++ b/Combine/law_combine.py
@@ -1548,6 +1548,7 @@ class AsimovImpactFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
         impactConfig = config["combine_impacts"]    
         
         tasks["RunT2WS"] = RunText2Workspace(output_dir=output_dir, variable=self.variable, year=self.year, version=self.variable if self.variable != "" else "inclusive", workflow=impactConfig["execution"], batch_flavor=self.batch_flavor, slurm_partition=impactConfig['batchPartition'], slurm_memory=impactConfig['batchMemory'], slurm_max_runtime=impactConfig['batchMaxRuntime'], htcondor_partition=impactConfig['batchPartition'], htcondor_memory=impactConfig['batchMemory'], htcondor_max_runtime=impactConfig['batchMaxRuntime'])
+        tasks["CreateAsimovFitFirstStep"] = CreateAsimovFitFirstStep(output_dir=output_dir, variable=self.variable, year=self.year, batch_flavor=self.batch_flavor)
         
         return tasks
 
@@ -1627,8 +1628,37 @@ class AsimovImpactFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
         else:
             execute_command([f'mkdir -p {output_dir}/Combine/{fitFolderName}/impact'], shell=True)
             os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'impact'))
+
+        first_output = os.path.join(output_dir, 'Combine', fitFolderName, 'asimov')
+        if self.variable == '':
+            pdf_idx_param = "r"
+        else:
+            pdf_idx_param = combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStrNoOne'][0]
+
+        def check_pdf_idx(param):
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            result = subprocess.run(command, shell=True, capture_output=True, text=True)
+            pdfIdx = result.stdout.strip()
+            if result.returncode != 0:
+                print("Error executing the command:", result.stderr)
+                return None
+            if pdfIdx.startswith("Processing"):
+                pdfIdx = pdfIdx.split('X', 1)[-1]
+            pdfIdx = pdfIdx.rstrip(',')
+            print(pdfIdx)
+            return pdfIdx
+
+        pdfIdx = None
+        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.38.root")
+        if os.path.exists(first_step_path):
+            pdfIdx = check_pdf_idx(pdf_idx_param)
+        else:
+            print(f"First-step file not found for PDF index extraction: {first_step_path}")
         
         if self.variable == '':
+            set_param_string = "r=1"
+            if pdfIdx:
+                set_param_string = f"{set_param_string},{pdfIdx}"
             arguments = [
                 "combineTool.py",
                 "-M", "Impacts",
@@ -1643,7 +1673,7 @@ class AsimovImpactFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
                 "--X-rtd", "MINIMIZER_multiMin_maskConstraints",
                 "--X-rtd", "MINIMIZER_multiMin_maskChannels=2",
                 "-t", "-1",
-                "--setParameters", "r=1"
+                "--setParameters", f"{set_param_string}"
             ]
             command = arguments
             # print(command)
@@ -1654,6 +1684,9 @@ class AsimovImpactFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
             except subprocess.CalledProcessError as e:
                 print("Error executing script:", e.stderr)
         else:
+            set_param_string = ",".join(combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStr'])
+            if pdfIdx:
+                set_param_string = f"{set_param_string},{pdfIdx}"
             arguments = [
                 "combine",
                 "-M", "MultiDimFit",
@@ -1669,7 +1702,7 @@ class AsimovImpactFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
                 "--X-rtd", "MINIMIZER_multiMin_maskConstraints",
                 "--X-rtd", "MINIMIZER_multiMin_maskChannels=2",
                 "-t", "-1",
-                "--setParameters", f"""{",".join(combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStr'])}"""
+                "--setParameters", f"{set_param_string}"
             ]
             command = arguments
             # print(command)
@@ -1876,7 +1909,36 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             execute_command([f'mkdir -p {output_dir}/Combine/{fitFolderName}/impact'], shell=True)
             os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'impact'))
 
+        first_output = os.path.join(output_dir, 'Combine', fitFolderName, 'asimov')
         if self.variable == '':
+            pdf_idx_param = "r"
+        else:
+            pdf_idx_param = combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStrNoOne'][0]
+
+        def check_pdf_idx(param):
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            result = subprocess.run(command, shell=True, capture_output=True, text=True)
+            pdfIdx = result.stdout.strip()
+            if result.returncode != 0:
+                print("Error executing the command:", result.stderr)
+                return None
+            if pdfIdx.startswith("Processing"):
+                pdfIdx = pdfIdx.split('X', 1)[-1]
+            pdfIdx = pdfIdx.rstrip(',')
+            print(pdfIdx)
+            return pdfIdx
+
+        pdfIdx = None
+        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.38.root")
+        if os.path.exists(first_step_path):
+            pdfIdx = check_pdf_idx(pdf_idx_param)
+        else:
+            print(f"First-step file not found for PDF index extraction: {first_step_path}")
+
+        if self.variable == '':
+            set_param_string = "r=1"
+            if pdfIdx:
+                set_param_string = f"{set_param_string},{pdfIdx}"
             arguments = [
                 "combine",
                 "-M", "MultiDimFit",
@@ -1896,7 +1958,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "--X-rtd", "MINIMIZER_multiMin_maskConstraints",
                 "--X-rtd", "MINIMIZER_multiMin_maskChannels=2",
                 "-t", "-1",
-                "--setParameters", "r=1"
+                "--setParameters", f"{set_param_string}"
             ]
             command = arguments
             # print(command)
@@ -1907,6 +1969,9 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             except subprocess.CalledProcessError as e:
                 print("Error executing script:", e.stderr)
         else:
+            set_param_string = ",".join(combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStr'])
+            if pdfIdx:
+                set_param_string = f"{set_param_string},{pdfIdx}"
             arguments = [
                 "combine",
                 "-M", "MultiDimFit",
@@ -1926,7 +1991,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "--X-rtd", "MINIMIZER_multiMin_maskConstraints",
                 "--X-rtd", "MINIMIZER_multiMin_maskChannels=2",
                 "-t", "-1",
-                "--setParameters", f"""{",".join(combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStr'])}"""
+                "--setParameters", f"{set_param_string}"
             ]
             command = arguments
             # print(command)
@@ -2096,6 +2161,38 @@ class AsimovImpactThirdStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
             os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'impact'))
             temp_output_dir = output_dir
 
+        first_output = os.path.join(output_dir, 'Combine', fitFolderName, 'asimov')
+        if self.variable == '':
+            pdf_idx_param = "r"
+            base_param_string = "r=1"
+        else:
+            pdf_idx_param = combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStrNoOne'][0]
+            base_param_string = ",".join(combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStr'])
+
+        def check_pdf_idx(param):
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            result = subprocess.run(command, shell=True, capture_output=True, text=True)
+            pdfIdx = result.stdout.strip()
+            if result.returncode != 0:
+                print("Error executing the command:", result.stderr)
+                return None
+            if pdfIdx.startswith("Processing"):
+                pdfIdx = pdfIdx.split('X', 1)[-1]
+            pdfIdx = pdfIdx.rstrip(',')
+            print(pdfIdx)
+            return pdfIdx
+
+        pdfIdx = None
+        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.38.root")
+        if os.path.exists(first_step_path):
+            pdfIdx = check_pdf_idx(pdf_idx_param)
+        else:
+            print(f"First-step file not found for PDF index extraction: {first_step_path}")
+
+        set_param_string = None
+        if pdfIdx:
+            set_param_string = f"{base_param_string},{pdfIdx}"
+
         if self.variable == '':
             arguments = [
                 "combineTool.py",
@@ -2104,6 +2201,8 @@ class AsimovImpactThirdStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
                 "-m", "125.38",
                 "-o", "impacts/impacts.json"
             ]
+            if set_param_string is not None:
+                arguments.extend(["--setParameters", set_param_string])
             command = arguments
             # print(command)
             try:
@@ -2155,6 +2254,8 @@ class AsimovImpactThirdStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
             if (config["combine_impacts"]["exclude"] != ""):
                 arguments.append("--exclude")
                 arguments.append(config["combine_impacts"]["exclude"])
+            if set_param_string is not None:
+                arguments.extend(["--setParameters", set_param_string])
             command = arguments
             # print(command)
             try:

--- a/config/2022_NJ.yml
+++ b/config/2022_NJ.yml
@@ -4,8 +4,8 @@ outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/o
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/Njets2p5/allData_2022.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/Njets2p5/root/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/Njets2p5/2022/data/allData_2022.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/Njets2p5/2022/signal'
 
 backgroundScriptCfg:
   # Setup

--- a/config/2022_PTH.yml
+++ b/config/2022_PTH.yml
@@ -1,11 +1,11 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_PTH/'
+outputFolder: '/net/data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_PTH'
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/PTH/allData_2022.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/PTH/root/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/PTH/2022/data/allData_2022.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/PTH/2022/signal'
 
 backgroundScriptCfg:
   # Setup
@@ -14,7 +14,7 @@ backgroundScriptCfg:
   ext: 'Run3FidXSAnalysis_PTH' # extension to add to output directory
   # year: '2022' # Use combined when merging all years in category (for plots)
   execution: 'htcondor'
-  batchPartition: "short" # Slurm partition to use for job submission
+  batchPartition: "standard" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 

--- a/config/2022_PTJ0.yml
+++ b/config/2022_PTJ0.yml
@@ -1,11 +1,11 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_ptJ0/'
+outputFolder: '/net/data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_PTJ0'
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/ptJ0/allData_2022.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/ptJ0/root/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/ptJ0/2022/data/allData_2022.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/ptJ0/2022/signal'
 
 backgroundScriptCfg:
   # Setup

--- a/config/2022_inclusive.yml
+++ b/config/2022_inclusive.yml
@@ -1,6 +1,6 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_inclusive'
+outputFolder: '/.automount/net_rw/net__data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_inclusive'
 
 inputFiles:
   # Trees2WS

--- a/config/2022_inclusive.yml
+++ b/config/2022_inclusive.yml
@@ -4,8 +4,8 @@ outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/o
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_07_18/data/allData_2022.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_07_18/signal'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/data/allData_2022.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/signal/2022'
 
 backgroundScriptCfg:
   # Setup

--- a/config/2022_rapidity.yml
+++ b/config/2022_rapidity.yml
@@ -4,8 +4,8 @@ outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/o
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/rapidity/allData_2022.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/rapidity/root/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/rapidity/2022/data/allData_2022.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/rapidity/2022/signal'
 
 backgroundScriptCfg:
   # Setup
@@ -13,7 +13,7 @@ backgroundScriptCfg:
   catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
   ext: 'Run3FidXSAnalysis_rapidity' # extension to add to output directory
   # year: '2022' # Use combined when merging all years in category (for plots)
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use

--- a/config/2023_NJ.yml
+++ b/config/2023_NJ.yml
@@ -4,8 +4,8 @@ outputFolder: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samp
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_06_12/intermediateRun3/variables/NJ/allData_2023.root'
-  Trees2WS: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_06_12/intermediateRun3/variables/NJ/root'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/Njets2p5/2023/data/allData_2023.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/Njets2p5/2023/signal'
 
 backgroundScriptCfg:
   # Setup

--- a/config/2023_PTH.yml
+++ b/config/2023_PTH.yml
@@ -4,8 +4,8 @@ outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/o
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/PTH/allData_2023.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/PTH/root/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/PTH/2023/data/allData_2023.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/PTH/2023/signal'
 
 backgroundScriptCfg:
   # Setup

--- a/config/2023_PTJ0.yml
+++ b/config/2023_PTJ0.yml
@@ -1,6 +1,6 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2023_ptJ0/'
+outputFolder: '/net/data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2023_PTJ0'
 
 inputFiles:
   # Trees2WS

--- a/config/2023_inclusive.yml
+++ b/config/2023_inclusive.yml
@@ -4,8 +4,8 @@ outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/o
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_07_18/data/allData_2023.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_07_18/signal'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/data/allData_2023.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/signal/2023'
 
 backgroundScriptCfg:
   # Setup

--- a/config/2023_rapidity.yml
+++ b/config/2023_rapidity.yml
@@ -4,8 +4,8 @@ outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/o
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/rapidity/allData_2023.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_07_18/rapidity/root/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/rapidity/2023/data/allData_2023.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_08_04_fixedFNUF/rapidity/2023/signal'
 
 backgroundScriptCfg:
   # Setup

--- a/config/2223_PTH.yml
+++ b/config/2223_PTH.yml
@@ -1,6 +1,6 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2223_PTH/'
+outputFolder: '/net/data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2223_PTH/'
 
 inputFiles:
   # Trees2WS

--- a/law/htcondor_setup.sh
+++ b/law/htcondor_setup.sh
@@ -2,7 +2,7 @@
 
 action() {
 
-    cd /work/niharrin/t35/CMSSW_14_1_0_pre4/src/flashggFinalFit
+    cd /net/data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/
     export ANALYSIS_PATH="$(pwd)"
     # The following source of cmsset_default.sh is needed on architectures other than lxplus, when the default cms commands are not sourced at startup
     export VO_CMS_SW_DIR="/cvmfs/cms.cern.ch"


### PR DESCRIPTION
This pull request introduces significant improvements to the impact calculation. A new step to extract the PDF index from the first fit output is added. It is included it in subsequent combine commands. This solves a similar issue that we often observe in the scans for the POIs, where the fit does not converge well when the pdf indices are not set to the values at the best-fit point (statistical cuase is not totally clear, but this works).

**Workflow and impact calculation improvements:**

* Added a new `CreateAsimovFitFirstStep` task to the workflow for the impacts in `law_combine.py`, ensuring the first step fit output is available for PDF index extraction.
* Implemented logic to extract the PDF index from the first-step fit output using a ROOT macro and include it in the `--setParameters` argument for combine commands, improving parameter accuracy for both inclusive and differential cases. [[1]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6R1632-R1661) [[2]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6L1646-R1676) [[3]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6R1687-R1689) [[4]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6L1672-R1705) [[5]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6R1912-R1941) [[6]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6L1899-R1961) [[7]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6R1972-R1974) [[8]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6L1929-R1994) [[9]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6R2164-R2195) [[10]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6R2204-R2205) [[11]](diffhunk://#diff-6d9c23288b613bdc5fc9b6ce55debd31eb5a36b290835d2746b8725d62f4e7a6R2257-R2258)

** Illustration**

The following two files illustrate the issue. The first, `impacts_problem.pdf` is generated from the current default branch and exhibits non-closure in the best-fit POI in the asimov and also shows pulls for nuisances. This should not happen for Asimov impacts in Hgg.

The `impacts_working.pdf` is generated using the implementation in the source branch of this PR. The problem is fixed by loading the best-fit PDF indices (but they are still allowed to float, of course).

[impacts_problem.pdf](https://github.com/user-attachments/files/23161096/impacts_problem.pdf)
[impacts_working.pdf](https://github.com/user-attachments/files/23161097/impacts_working.pdf)
