### PR TITLE
Implementation of combinedCard feature for inclusive result. Fix for 2024 (year without era). + other small stuff

### DIFF
--- a/Datacard/law_datacard.py
+++ b/Datacard/law_datacard.py
@@ -234,17 +234,26 @@ class MakeYields(law.Task): #law.Task
                     else:
                         inputWSDirMap += currentYearEra + "=" + currentYearEraInputOutput
         else:
-            for j, currentEra in enumerate(allErasMap[self.year]):
-                currentYearEra = self.year + currentEra
-                if self.variable == '':
-                    currentYearEraInputOutput = os.path.join(output_dir, "input_output_{}{}/ws_signal".format(self.year, currentEra))
+            eras = allErasMap.get(f"{self.year}", [""])
+
+            for j, currentEra in enumerate(eras):
+                era_suffix = "" if currentEra in ["", "None"] else currentEra
+                currentYearEra = f"{self.year}{era_suffix}"
+
+                if self.variable == "":
+                    currentYearEraInputOutput = os.path.join(
+                        output_dir, f"input_output_{self.year}{era_suffix}/ws_signal"
+                    )
                 else:
-                    currentYearEraInputOutput = os.path.join(output_dir, "input_output_{}_{}{}/ws_signal".format(self.variable, self.year, currentEra))
-                if (j != len(allErasMap[self.year]) - 1):  # Check if it's the last element of the last year
-                    inputWSDirMap += currentYearEra + "=" + currentYearEraInputOutput + ","
+                    currentYearEraInputOutput = os.path.join(
+                        output_dir, f"input_output_{self.variable}_{self.year}{era_suffix}/ws_signal"
+                    )
+
+                if j != len(eras) - 1:
+                    inputWSDirMap += f"{currentYearEra}={currentYearEraInputOutput},"
                 else:
-                    inputWSDirMap += currentYearEra + "=" + currentYearEraInputOutput
-        
+                    inputWSDirMap += f"{currentYearEra}={currentYearEraInputOutput}"
+
         tasks = [MakeYieldsCategory(inputWSDirMap=inputWSDirMap, output_dir=output_dir, year=self.year, cats=datacard_config['cats'], procs=datacard_config['procs'], nCats=datacard_config['nCats'], ext=datacard_config['ext'], mergeYears=datacard_config['mergeYears'], skipBkg=datacard_config['skipBkg'], bkgScaler=datacard_config['bkgScaler'], sigModelWSDir=datacard_config['sigModelWSDir'], sigModelExt=f"packaged{packaged_config['ext']}", bkgModelWSDir=datacard_config['bkgModelWSDir'], bkgModelExt=datacard_config['bkgModelExt'], skipZeroes=datacard_config['skipZeroes'], skipCOWCorr=datacard_config['skipCOWCorr'], doSystematics=datacard_config['doSystematics'], ignore_warnings=datacard_config['ignore_warnings'], mass=datacard_config['mass'], variable=self.variable, version='v1', workflow=datacard_config['execution'], batch_flavor=self.batch_flavor, slurm_partition=datacard_config['batchPartition'], slurm_memory=datacard_config['batchMemory'], slurm_max_runtime=datacard_config['batchMaxRuntime'], htcondor_partition=datacard_config['batchPartition'], htcondor_memory=datacard_config['batchMemory'], htcondor_max_runtime=datacard_config['batchMaxRuntime'])]
         
         return tasks
@@ -425,13 +434,17 @@ class MakeDatacard(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #l
                     else:
                         years += currentYearEra
         else:
-            for j, currentEra in enumerate(allErasMap[self.year]):
-                currentYearEra = self.year + currentEra
-                if (j != len(allErasMap[self.year]) - 1):  # Check if it's the last element of the last year
+            eras = allErasMap.get(self.year, [""])
+
+            for j, currentEra in enumerate(eras):
+                era_suffix = "" if currentEra in ["", "None"] else currentEra
+                currentYearEra = f"{self.year}{era_suffix}"
+
+                if j != len(eras) - 1:
                     years += currentYearEra + ","
                 else:
                     years += currentYearEra
-        
+
         script_path = os.path.join(os.environ["ANALYSIS_PATH"], "Datacard/makeDatacard.py")
         arguments = [
             "python3",

--- a/Signal/law_signal.py
+++ b/Signal/law_signal.py
@@ -201,16 +201,24 @@ class FTest(law.Task):
         
         i = 1
         # Loop over a years era
-        for currentEra in allErasMap[f"{self.year}"]:
-            
-            
-            if self.variable == '':
-                input_path = os.path.join(config["outputFolder"], f"input_output_{self.year}{currentEra}/ws_signal")
+        eras = allErasMap.get(f"{self.year}", [""])
+
+        for currentEra in eras:
+
+            era_suffix = "" if currentEra in ["", "None"] else currentEra
+
+            if self.variable == "":
+                input_path = os.path.join(
+                    config["outputFolder"],
+                    f"input_output_{self.year}{era_suffix}/ws_signal"
+                )
             else:
-                input_path = os.path.join(config["outputFolder"], f"input_output_{self.variable}_{self.year}{currentEra}/ws_signal")
+                input_path = os.path.join(
+                    config["outputFolder"],
+                    f"input_output_{self.variable}_{self.year}{era_suffix}/ws_signal"
+                )
 
-
-            if currentEra != "None":
+            if currentEra not in ["", "None"]:
                 currentConfig = config[f"signalScriptCfg_{self.year}_{currentEra}"]
             else:
                 currentConfig = config[f"signalScriptCfg_{self.year}"]
@@ -257,10 +265,14 @@ class FTest(law.Task):
         output_paths = []
 
         # Loop over a years era
-        for currentEra in allErasMap[f"{self.year}"]:
+        eras = allErasMap.get(f"{self.year}", [""])
+        
+        for currentEra in eras:
+            
+            era_suffix = "" if currentEra in ["", "None"] else currentEra
 
-            if currentEra != "None":
-                currentConfig = config[f"signalScriptCfg_{self.year}_{currentEra}"]
+            if currentEra not in ["", "None"]:
+                currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
             else:
                 currentConfig = config[f"signalScriptCfg_{self.year}"]
             # returns output folder
@@ -463,16 +475,20 @@ class CalcPhotonSyst(law.Task):
         
         i = 1
         # Loop over a years era
-        for currentEra in allErasMap[f"{self.year}"]:
+        eras = allErasMap.get(f"{self.year}", [""])
+        
+        for currentEra in eras:
+            
+            era_suffix = "" if currentEra in ["", "None"] else currentEra
             
             if self.variable == '':
-                input_path = os.path.join(config["outputFolder"], f"input_output_{self.year}{currentEra}/ws_signal")
+                input_path = os.path.join(config["outputFolder"], f"input_output_{self.year}{era_suffix}/ws_signal")
             else:
-                input_path = os.path.join(config["outputFolder"], f"input_output_{self.variable}_{self.year}{currentEra}/ws_signal")
+                input_path = os.path.join(config["outputFolder"], f"input_output_{self.variable}_{self.year}{era_suffix}/ws_signal")
 
 
-            if currentEra != "None":
-                currentConfig = config[f"signalScriptCfg_{self.year}_{currentEra}"]
+            if currentEra not in ["", "None"]:
+                currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
             else:
                 currentConfig = config[f"signalScriptCfg_{self.year}"]
                 
@@ -518,10 +534,14 @@ class CalcPhotonSyst(law.Task):
         output_paths = []
         
         # Loop over a years era
-        for currentEra in allErasMap[f"{self.year}"]:
+        eras = allErasMap.get(f"{self.year}", [""])
+        
+        for currentEra in eras:
             
-            if currentEra != "None":
-                currentConfig = config[f"signalScriptCfg_{self.year}_{currentEra}"]
+            era_suffix = "" if currentEra in ["", "None"] else currentEra
+
+            if currentEra not in ["", "None"]:
+                currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
             else:
                 currentConfig = config[f"signalScriptCfg_{self.year}"]
             # returns output folder
@@ -748,14 +768,21 @@ class SignalFit(law.Task):
             
         i = 1
         # Loop over a years era
-        for currentEra in allErasMap[f"{self.year}"]:
+        eras = allErasMap.get(f"{self.year}", [""])
+        
+        for currentEra in eras:
+            
+            era_suffix = "" if currentEra in ["", "None"] else currentEra
             
             if self.variable == "":
-                input_path = os.path.join(config["outputFolder"], f"input_output_{self.year}{currentEra}/ws_signal")
+                input_path = os.path.join(config["outputFolder"], f"input_output_{self.year}{era_suffix}/ws_signal")
             else:
-                input_path = os.path.join(config["outputFolder"], f"input_output_{self.variable}_{self.year}{currentEra}/ws_signal")
+                input_path = os.path.join(config["outputFolder"], f"input_output_{self.variable}_{self.year}{era_suffix}/ws_signal")
 
-            currentConfig = config[f"signalScriptCfg_{self.year}_{currentEra}"]
+            if currentEra not in ["", "None"]:
+                currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
+            else:
+                currentConfig = config[f"signalScriptCfg_{self.year}"]
 
             # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             # If proc/cat == auto. Extract processes and categories
@@ -804,10 +831,17 @@ class SignalFit(law.Task):
         data_input_path = config['inputFiles']['Trees2WSData']  
 
         # Loop over a years era
-        for currentEra in allErasMap[f"{self.year}"]:
-
-            currentConfig = config[f"signalScriptCfg_{self.year}_{currentEra}"]
+        eras = allErasMap.get(f"{self.year}", [""])
+        
+        for currentEra in eras:
             
+            era_suffix = "" if currentEra in ["", "None"] else currentEra
+
+            if currentEra not in ["", "None"]:
+                currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
+            else:
+                currentConfig = config[f"signalScriptCfg_{self.year}"]
+
             # returns output folder
             output_paths.append(law.LocalFileTarget(os.path.join(output_dir, f"outdir_{currentConfig['ext']}/signalFit")))
             output_paths.append(law.LocalFileTarget(os.path.join(output_dir, f"outdir_{currentConfig['ext']}/signalFit/output")))
@@ -935,8 +969,16 @@ class SignalPackagingCategory(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWo
             #Load central config file
             with open(configYamlPath, 'r') as file:
                 config = yaml.safe_load(file)
-            for currentEra in allErasMap[f"{self.year}"]:
-                signalScriptCfg = config[f"signalScriptCfg_{self.year}_{currentEra}"]
+            eras = allErasMap.get(f"{self.year}", [""])
+            
+            for currentEra in eras:
+                
+                era_suffix = "" if currentEra in ["", "None"] else currentEra
+        
+                if currentEra not in ["", "None"]:
+                    signalScriptCfg = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
+                else:
+                    signalScriptCfg = config[f"signalScriptCfg_{self.year}"]
                 # Have to copy over the input to the JOB directory
                 # Don't forget to VOMS!
                 if "/work" in self.output_dir:
@@ -1042,10 +1084,14 @@ class SignalPackaging(law.Task):
         exts = []
             
         # Loop over a years era and extract the ext string in a list
-        for currentEra in allErasMap[f"{self.year}"]:
-
-            currentConfig = config[f"signalScriptCfg_{self.year}_{currentEra}"]
+        eras = allErasMap.get(f"{self.year}", [""])
+        
+        for currentEra in eras:
             
+            era_suffix = "" if currentEra in ["", "None"] else currentEra
+
+            currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
+
             exts.append(currentConfig['ext'])
         
         exts_string = ''

--- a/Signal/law_signal.py
+++ b/Signal/law_signal.py
@@ -976,15 +976,15 @@ class SignalPackagingCategory(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWo
                 era_suffix = "" if currentEra in ["", "None"] else currentEra
         
                 if currentEra not in ["", "None"]:
-                    signalScriptCfg = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
+                    currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
                 else:
-                    signalScriptCfg = config[f"signalScriptCfg_{self.year}"]
+                    currentConfig = config[f"signalScriptCfg_{self.year}"]
                 # Have to copy over the input to the JOB directory
                 # Don't forget to VOMS!
                 if "/work" in self.output_dir:
                     slurm_copy_command = [
                         'cp', '-rf',
-                        f"{self.output_dir}/outdir_{signalScriptCfg['ext']}",
+                        f"{self.output_dir}/outdir_{currentConfig['ext']}",
                         f"{os.environ['TARGET_PATH']}/"
                     ]
                 else:
@@ -1090,7 +1090,10 @@ class SignalPackaging(law.Task):
             
             era_suffix = "" if currentEra in ["", "None"] else currentEra
 
-            currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
+            if currentEra not in ["", "None"]:
+                currentConfig = config[f"signalScriptCfg_{self.year}_{era_suffix}"]
+            else:
+                currentConfig = config[f"signalScriptCfg_{self.year}"]
 
             exts.append(currentConfig['ext'])
         

--- a/Trees2WS/law_trees2ws.py
+++ b/Trees2WS/law_trees2ws.py
@@ -676,18 +676,26 @@ class Trees2WS(law.Task):
 
         tasks = []
         
+        eras = allErasMap.get(f"{self.year}", [""])
+
         era_list = [
-        (era, self.variable, input_paths)
-        for era in allErasMap[f"{self.year}"]
+            (era, self.variable, input_paths)
+            for era in eras
         ]
-            
+
         i = 1
         for era, var, path_to_root_files in era_list:
-            if var == '':
-                current_output_path = output_dir + "/input_output_{}{}".format(self.year, era)
+            era_suffix = "" if era in ["", "None"] else era
+
+            if var == "":
+                current_output_path = os.path.join(
+                    output_dir, f"input_output_{self.year}{era_suffix}"
+                )
             else:
-                current_output_path = output_dir + "/input_output_{}_{}{}".format(var, self.year, era)
-                            
+                current_output_path = os.path.join(
+                    output_dir, f"input_output_{var}_{self.year}{era_suffix}"
+                )
+             
             tasks.append(Trees2WSSingleProcess(input_paths=path_to_root_files, era=era, apply_mass_cut=mass_cut, mass_cut_range=mass_cut_r, year=f"{self.year}{era}", doSystematics=doSystematics, doDiffSplitting=doDiffSplitting, doSTXSSplitting=doSTXSSplitting, doInOutSplitting=doInOutSplitting, output_dir=current_output_path, variable=var, version=f"v{i}", workflow=config['execution'], batch_flavor=self.batch_flavor, slurm_partition=config['batchPartition'], slurm_memory=config['batchMemory'], slurm_max_runtime=config['batchMaxRuntime'], htcondor_partition=config['batchPartition'], htcondor_memory=config['batchMemory'], htcondor_max_runtime=config['batchMaxRuntime']))
             i += 1
         return tasks
@@ -709,18 +717,23 @@ class Trees2WS(law.Task):
         
         input_paths = config["inputFiles"]["Trees2WS"]
         
+        eras = allErasMap.get(f"{self.year}", [""])
+
         era_list_with_variable = [
             (era, self.variable)
-            for era in allErasMap[f"{self.year}"]
+            for era in eras
         ]
+
         outputFolders = []
         for era, var in era_list_with_variable:
-            if var == '':
-                current_output_path = output_dir + "/input_output_{}{}".format(self.year, era)
+            era_suffix = "" if era in ["", "None"] else era
+
+            if var == "":
+                current_output_path = os.path.join(output_dir, f"input_output_{self.year}{era_suffix}")
             else:
-                current_output_path = output_dir + "/input_output_{}_{}{}".format(var, self.year, era)
-                
-            outputFolders.append(law.LocalFileTarget(current_output_path + '/ws_signal'))
+                current_output_path = os.path.join(output_dir, f"input_output_{var}_{self.year}{era_suffix}")
+
+            outputFolders.append(law.LocalFileTarget(os.path.join(current_output_path, "ws_signal")))
 
         return outputFolders
     
@@ -741,46 +754,43 @@ class Trees2WS(law.Task):
         else:
             output_dir = self.output_dir
         
-        era_list_with_variable = [
-            (era, self.variable)
-            for era in allErasMap[f"{self.year}"]
-        ]
+        eras = allErasMap.get(str(self.year), [""])
+        
+        era_list_with_variable = [(era, self.variable) for era in eras]
         
         outputFolders = []
         for era, var in era_list_with_variable:
-            if var == '':
-                current_output_path = os.path.join(output_dir, "input_output_{}{}".format(self.year, era))
+            era_suffix = "" if era in ["", "None"] else era
+
+            if var == "":
+                current_output_path = os.path.join(output_dir, f"input_output_{self.year}{era_suffix}")
             else:
-                current_output_path = os.path.join(output_dir, "input_output_{}_{}{}".format(var, self.year, era))
+                current_output_path = os.path.join(output_dir, f"input_output_{var}_{self.year}{era_suffix}")
+
             outputFolders.append(current_output_path)
 
-            
         for currentEra in outputFolders:
-            # Create ws_signal folder
-            dst_folder = currentEra + "/ws_signal"
+            dst_folder = os.path.join(currentEra, "ws_signal")
+
             if not os.path.exists(dst_folder):
                 if self.batch_flavor == "slurm/psi":
                     execute_command([f'xrdfs root://t3dcachedb03.psi.ch:1094/ mkdir -p {dst_folder}'], shell=True)
                 else:
                     safe_mkdir(dst_folder)
-            
-            # Copy files to ws_signal
+
             src_file_list = glob.glob(os.path.join(currentEra, "ws_*", "*"))
             for currentFile in src_file_list:
                 if not os.path.samefile(currentFile, dst_folder):
                     if self.batch_flavor == "slurm/psi":
-                        if '/pnfs' in currentFile:
-                            currentFile = currentFile.replace('/pnfs', 'root://t3dcachedb03.psi.ch:1094//pnfs')
-                        elif '/pnfs' in dst_folder:
-                            dst_folder = dst_folder.replace('/pnfs', 'root://t3dcachedb03.psi.ch:1094//pnfs')
-                        execute_command([f'xrdcp -rf {currentFile} {dst_folder}'], shell=True)
+                        if "/pnfs" in currentFile:
+                            currentFile = currentFile.replace("/pnfs", "root://t3dcachedb03.psi.ch:1094//pnfs")
+                        elif "/pnfs" in dst_folder:
+                            dst_folder = dst_folder.replace("/pnfs", "root://t3dcachedb03.psi.ch:1094//pnfs")
+                        execute_command([f"xrdcp -rf {currentFile} {dst_folder}"], shell=True)
                     else:
                         shutil.copy2(currentFile, dst_folder)
                 else:
                     print(f"Skip copying {currentFile} since it is already in ws_signal.")
-            
-        print("Copy completed.")
 
+        print("Copy completed.")
         return True
-    
-    

--- a/commonTools/commonObjects.py
+++ b/commonTools/commonObjects.py
@@ -128,7 +128,7 @@ allErasMap = {
     '2022': ["preEE", "postEE"],
     '2023': ["preBPix", "postBPix"],
     '2223': ["preEE", "postEE", "preBPix", "postBPix"],
-    '2024': ["all"],
+    # 2024 does not have eras
     'Run3': ["preEE", "postEE", "preBPix", "postBPix"],
 }
 

--- a/config/2022_2023_2024_inclusive.yml
+++ b/config/2022_2023_2024_inclusive.yml
@@ -1,19 +1,19 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2024_inclusive/'
+outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_2023_2024_inclusive/'
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/data/allData_2024_allRuns.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/signal/2024/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/data/allData.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/signal/2223/'
 
 backgroundScriptCfg:
   # Setup
   cats: 'auto' # auto: automatically inferred from input ws
   catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
   ext: 'Run3FidXSAnalysis' # extension to add to output directory
-  year: '2024' # Use combined when merging all years in category (for plots)
-  execution: 'htcondor'
+  year: 'Run3' # Use combined when merging all years in category (for plots)
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -51,6 +51,8 @@ trees2wsCfg:
     - "weight"
     - "fiducialGeometricFlag"
   
+  # Do empty dict, only this way it works
+  # theoryWeightContainers: {}
   theoryWeightContainers:
     weight_LHEPdf: 101
     weight_LHEScale: 9
@@ -66,58 +68,138 @@ trees2wsCfg:
 
   cats: 'auto'
 
-  execution: 'htcondor'
-  batchPartition: "short" # Slurm partition to use for job submission
-  batchMemory: 10000 # Slurm memory to use for job submission
+  execution: 'local'
+  batchPartition: "workday" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
-
-signalScriptCfg_2024:
+signalScriptCfg_2223_preEE:
   # Setup
   procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
   cats: 'auto' # if auto: inferred automatically from (0) workspace
-  ext: 'Run3FidXSAnalysis_2024' # output directory extension
+  ext: 'Run3FidXSAnalysis_2223preEE' # output directory extension
   analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
   analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
-  year: '2024' # Use 'combined' if merging all years: not recommended
+  year: '2223preEE' # Use 'combined' if merging all years: not recommended
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
   replacementThreshold: '50'
   # Photon shape systematics  
   scales: 'ScaleEE,ScaleEB' # separate nuisance per year
-  scalesCorr: ''
-  #scalesCorr: 'FNUF,Material' # correlated across years
+  scalesCorr: 'FNUF,Material' # correlated across years
   scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
   smears: 'Smearing' # separate nuisance per year
 
   doPlots: True
 
-  beamspotWidthData: '3.583'
-  beamspotWidthMC: '3.601'
+  beamspotWidthData: '3.2'
+  beamspotWidthMC: '3.732'
 
 
   # Job submission options
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
+signalScriptCfg_2223_postEE:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_2223postEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223postEE' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '50'
+  # Photon shape systematics  
+  scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  scalesCorr: 'FNUF,Material' # correlated across years
+  scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
 
-packaged_2024:
+  doPlots: True
+
+  
+  beamspotWidthData: '3.5'
+  beamspotWidthMC: '3.732'
+
+  # Job submission options
+  execution: 'local'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_preBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_2223preBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223preBPix' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '50'
+  # Photon shape systematics  
+  scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  #scalesCorr: ''
+  scalesCorr: 'FNUF,Material' # correlated across years
+  scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.703'
+  beamspotWidthMC: '3.597'
+
+  # Job submission options
+  execution: 'local'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_postBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_2223postBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223postBPix' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '50'
+  # Photon shape systematics
+  scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  #scalesCorr: ''
+  scalesCorr: 'FNUF,Material' # correlated across years
+  scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.737'
+  beamspotWidthMC: '3.597'
+
+  # Job submission options
+  execution: 'local'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+packaged_2223:
   cats: 'auto' # if auto: inferred automatically from (0) workspace
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
   mergeYears: True # Merges the eras
   ext: ''
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 datacard_yields:
   cats: 'auto' # if auto: inferred automatically from (0) workspace
   procs: 'auto' # if auto: inferred automatically from (0) workspace
   ext: 'Run3FidXSAnalysis' # Extension for saving
-  inputWSDirMap: '2024'
+  inputWSDirMap: '2223preEE,2223postEE,2223preBPix,2223postBPix'
   sigModelWSDir: './Models/signal' # Input signal model WS directory
   bkgModelWSDir: './Models/background' # Input background model WS directory
   bkgModelExt: 'multipdf' # Extension used when saving background model
@@ -129,11 +211,10 @@ datacard_yields:
   skipBkg: False # Only add signal processes to datacard
   bkgScaler: 1. # Add overall scale factor for background
   skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 datacard:
   # For pruning processes
@@ -151,7 +232,7 @@ datacard:
 
   # For output:
   saveDataFrame: False # Save final dataframe as pkl file
-  output: 'Datacard_2024' # Datacard name
+  output: 'Datacard_2022_2023_2024' # Datacard name
 
 datacard_clean:
   factor: 10000 # Factor beyond which uncertainty is considered incorrect and is removed
@@ -161,21 +242,15 @@ datacard_clean:
   verbose: False # Spit out all the cleaning being done
 
 combine_fit:
-  asimov_numPoints: 100 # Number of points the Asimov generator should generate for the NLL scan
+  asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
   unblindedFit_numPoints: 100 
   setParameterRange: "r=0,2"
   cminApproxPreFitTolerance: 0.01
   rMin: 0.7
   rMax: 1.6
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
-  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
-combine_SplusB_toys:
-  execution: 'htcondor'
-  batchPartition: "short" # Slurm partition to use for job submission
-  batchMemory: 11000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
 combine_impacts:
@@ -185,24 +260,22 @@ combine_impacts:
   stepSize: 0.05
   setCrossingTolerance: 0.00005 
   not_show_POI: False
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 combine_hesse:
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 combine_mggToys:
   nToys: 1000 # Number of toys = nToys * 10
   loadSnapshot: 'MultiDimFit'
   doBands: True
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use

--- a/config/2022_2023_inclusive.yml
+++ b/config/2022_2023_inclusive.yml
@@ -1,19 +1,19 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2024_inclusive/'
+outputFolder: '/net/data_cms3a-1/wrabetz/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_2023_inclusive/'
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/data/allData_2024_allRuns.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/signal/2024/'
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/data/allData.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/inclusive/2025_08_04_fixedFNUF/signal/2223/'
 
 backgroundScriptCfg:
   # Setup
   cats: 'auto' # auto: automatically inferred from input ws
   catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
   ext: 'Run3FidXSAnalysis' # extension to add to output directory
-  year: '2024' # Use combined when merging all years in category (for plots)
-  execution: 'htcondor'
+  year: 'Run3' # Use combined when merging all years in category (for plots)
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -51,6 +51,8 @@ trees2wsCfg:
     - "weight"
     - "fiducialGeometricFlag"
   
+  # Do empty dict, only this way it works
+  # theoryWeightContainers: {}
   theoryWeightContainers:
     weight_LHEPdf: 101
     weight_LHEScale: 9
@@ -66,58 +68,138 @@ trees2wsCfg:
 
   cats: 'auto'
 
-  execution: 'htcondor'
-  batchPartition: "short" # Slurm partition to use for job submission
-  batchMemory: 10000 # Slurm memory to use for job submission
+  execution: 'local'
+  batchPartition: "workday" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
-
-signalScriptCfg_2024:
+signalScriptCfg_2223_preEE:
   # Setup
   procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
   cats: 'auto' # if auto: inferred automatically from (0) workspace
-  ext: 'Run3FidXSAnalysis_2024' # output directory extension
+  ext: 'Run3FidXSAnalysis_2223preEE' # output directory extension
   analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
   analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
-  year: '2024' # Use 'combined' if merging all years: not recommended
+  year: '2223preEE' # Use 'combined' if merging all years: not recommended
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
   replacementThreshold: '50'
   # Photon shape systematics  
   scales: 'ScaleEE,ScaleEB' # separate nuisance per year
-  scalesCorr: ''
-  #scalesCorr: 'FNUF,Material' # correlated across years
+  scalesCorr: 'FNUF,Material' # correlated across years
   scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
   smears: 'Smearing' # separate nuisance per year
 
   doPlots: True
 
-  beamspotWidthData: '3.583'
-  beamspotWidthMC: '3.601'
+  beamspotWidthData: '3.2'
+  beamspotWidthMC: '3.732'
 
 
   # Job submission options
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
+signalScriptCfg_2223_postEE:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_2223postEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223postEE' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '50'
+  # Photon shape systematics  
+  scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  scalesCorr: 'FNUF,Material' # correlated across years
+  scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
 
-packaged_2024:
+  doPlots: True
+
+  
+  beamspotWidthData: '3.5'
+  beamspotWidthMC: '3.732'
+
+  # Job submission options
+  execution: 'local'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_preBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_2223preBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223preBPix' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '50'
+  # Photon shape systematics  
+  scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  #scalesCorr: ''
+  scalesCorr: 'FNUF,Material' # correlated across years
+  scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.703'
+  beamspotWidthMC: '3.597'
+
+  # Job submission options
+  execution: 'local'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_postBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_2223postBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisInclusive' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223postBPix' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '50'
+  # Photon shape systematics
+  scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  #scalesCorr: ''
+  scalesCorr: 'FNUF,Material' # correlated across years
+  scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.737'
+  beamspotWidthMC: '3.597'
+
+  # Job submission options
+  execution: 'local'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+packaged_2223:
   cats: 'auto' # if auto: inferred automatically from (0) workspace
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
   mergeYears: True # Merges the eras
   ext: ''
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 datacard_yields:
   cats: 'auto' # if auto: inferred automatically from (0) workspace
   procs: 'auto' # if auto: inferred automatically from (0) workspace
   ext: 'Run3FidXSAnalysis' # Extension for saving
-  inputWSDirMap: '2024'
+  inputWSDirMap: '2223preEE,2223postEE,2223preBPix,2223postBPix'
   sigModelWSDir: './Models/signal' # Input signal model WS directory
   bkgModelWSDir: './Models/background' # Input background model WS directory
   bkgModelExt: 'multipdf' # Extension used when saving background model
@@ -129,11 +211,10 @@ datacard_yields:
   skipBkg: False # Only add signal processes to datacard
   bkgScaler: 1. # Add overall scale factor for background
   skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 datacard:
   # For pruning processes
@@ -151,7 +232,7 @@ datacard:
 
   # For output:
   saveDataFrame: False # Save final dataframe as pkl file
-  output: 'Datacard_2024' # Datacard name
+  output: 'Datacard_2022_2023' # Datacard name
 
 datacard_clean:
   factor: 10000 # Factor beyond which uncertainty is considered incorrect and is removed
@@ -161,21 +242,15 @@ datacard_clean:
   verbose: False # Spit out all the cleaning being done
 
 combine_fit:
-  asimov_numPoints: 100 # Number of points the Asimov generator should generate for the NLL scan
+  asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
   unblindedFit_numPoints: 100 
   setParameterRange: "r=0,2"
   cminApproxPreFitTolerance: 0.01
   rMin: 0.7
   rMax: 1.6
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
-  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
-combine_SplusB_toys:
-  execution: 'htcondor'
-  batchPartition: "short" # Slurm partition to use for job submission
-  batchMemory: 11000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
 combine_impacts:
@@ -185,24 +260,22 @@ combine_impacts:
   stepSize: 0.05
   setCrossingTolerance: 0.00005 
   not_show_POI: False
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 combine_hesse:
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
-
 
 combine_mggToys:
   nToys: 1000 # Number of toys = nToys * 10
   loadSnapshot: 'MultiDimFit'
   doBands: True
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use

--- a/law/analysis.py
+++ b/law/analysis.py
@@ -13,6 +13,7 @@ from Trees2WS.law_trees2ws import *
 from Signal.law_signal import *
 from Combine.law_combine import *
 from Plots.Spectra.law_spectra import *
+from pathlib import Path
 
 # Function to safely create a directory
 def safe_mkdir(path):
@@ -28,7 +29,204 @@ def convert_boolean_string(string):
     else:
         return False
 
-class FinalFits(law.Task):
+class FinalFits(law.WrapperTask):
+    years = law.Parameter(default="2022,2023,2024")
+    variable = law.Parameter(default="")
+    output_dir = law.Parameter(default="")
+    
+    unblinded_fits = law.Parameter(default=False)
+    unblinded_stage_one = law.Parameter(default=False)
+    unblinded_stage_two = law.Parameter(default=False)
+    unblinded_stage_three = law.Parameter(default=False)
+    unblinded_covcorr = law.Parameter(default=False)
+    pvalue = law.Parameter(default=False)
+    asimov_fits = law.Parameter(default=False)
+    asimov_impacts = law.Parameter(default=False)
+    asimov_covcorr = law.Parameter(default=False)
+    unblinded_diff_spectra = law.Parameter(default=False)
+    asimov_diff_spectra = law.Parameter(default=False)
+    batch_system = law.Parameter(default="htcondor")
+    batch_flavor = law.Parameter(default="htcondor")
+
+    def requires(self):
+        years = [y.strip() for y in self.years.split(",") if y.strip()]
+        return [
+            FinalFitsYear(
+                variable=self.variable,
+                output_dir=self.output_dir,
+                year=y,
+                unblinded_fits=self.unblinded_fits,
+                unblinded_stage_one=self.unblinded_stage_one,
+                unblinded_stage_two=self.unblinded_stage_two,
+                unblinded_stage_three=self.unblinded_stage_three,
+                unblinded_covcorr=self.unblinded_covcorr,
+                pvalue=self.pvalue,
+                asimov_fits=self.asimov_fits,
+                asimov_impacts=self.asimov_impacts,
+                asimov_covcorr=self.asimov_covcorr,
+                unblinded_diff_spectra=self.unblinded_diff_spectra,
+                asimov_diff_spectra=self.asimov_diff_spectra,
+                batch_system=self.batch_system,
+                batch_flavor=self.batch_flavor,
+            )
+            for y in years
+        ]
+        
+
+    def run(self):
+        # --- paths relative to 'law' ---
+        law_dir = Path(__file__).resolve().parent
+        base_dir = law_dir.parent  # flashggFinalFit/
+        config_dir = base_dir / "config"
+        combine_dir = base_dir / "Combine"
+
+        years = [y.strip() for y in self.years.split(",") if y.strip()]
+        if len(years) < 2:
+            print(f"Single-year mode: {years[0]}. Nothing to combine.")
+            return True
+
+        combined_label = "_".join(years)
+        combined_output_dir = base_dir / f"output_{combined_label}_inclusive" / "Combine"
+        combined_output_dir.mkdir(parents=True, exist_ok=True)
+        
+        root_path = base_dir / f"output_{combined_label}_inclusive" / "Combine" / f"Datacard_{combined_label}.root"
+
+        if root_path.exists() and root_path.stat().st_size > 0:
+            print(f"Combined workspace already exists: {root_path}")
+            print("Skipping all intermediate steps (datacard/model copy, combine, text2workspace).")
+        else:
+            print("Combined .root file not found or empty — running Combine setup and workspace creation ...")
+            
+            # --- 1. Get output paths from configs ---
+            year_output_paths = {}
+            for y in years:
+                config_path = config_dir / f"{y}_inclusive.yml"
+                if config_path.exists():
+                    with open(config_path) as f:
+                        cfg = yaml.safe_load(f)
+                    year_output_paths[y] = Path(cfg["outputFolder"].rstrip("/"))
+                else:
+                    # fallback
+                    year_output_paths[y] = base_dir / f"output_{y}_inclusive"
+                    print(f"Using default path for {y}: {year_output_paths[y]}")
+
+            # --- 2. Copy Datacards ---
+            for y, out_path in year_output_paths.items():
+                src = out_path / "Combine" / f"Datacard_{y}.txt"
+                dst = combined_output_dir / f"Datacard_{y}.txt"
+                if src.exists():
+                    shutil.copy2(src, dst)
+                    print(f"Copied datacard for {y}")
+                else:
+                    print(f"⚠️  Missing datacard: {src}")
+
+            # --- 3. Copy Models ---
+            for y, out_path in year_output_paths.items():
+                src_models = out_path / "Combine" / "Models"
+                dst_models = combined_output_dir / f"Models_{y}"
+                if src_models.exists():
+                    shutil.copytree(src_models, dst_models, dirs_exist_ok=True)
+                    print(f"Copied models for {y}")
+                else:
+                    print(f"Missing models directory: {src_models}")
+
+            # --- 4. Combine datacards ---
+            os.chdir(combined_output_dir)
+            card_args = " ".join([f"Y{y[-2:]}=Datacard_{y}.txt" for y in years])
+            combined_card = f"Datacard_{combined_label}.txt"
+
+            print("Combining datacards...")
+            subprocess.run(f"combineCards.py {card_args} > {combined_card}", shell=True, check=True)
+
+            # --- 5. Fix model paths per year ---
+            print("Fixing model paths per year...")
+            for y in years:
+                tag = f"Y{y[-2:]}"
+                models_dir = f"./Models_{y}/"
+                subprocess.run(
+                    f"sed -i -E '/^shapes\\s+\\S+\\s+{tag}_/ s|(\\s)\\./Models/|\\1{models_dir}|g' {combined_card}",
+                    shell=True,
+                    check=True,
+                )
+
+            # --- 6. Delete some stuff ---
+            for y in years:
+                tmp_path = combined_output_dir / f"Datacard_{y}.txt"
+                if tmp_path.exists():
+                    tmp_path.unlink()
+
+            # --- 7. run RunText2Workspace for new Datacard ---
+            print("Running RunText2Workspace.py...")
+            runtext2ws_path = combine_dir / "RunText2Workspace.py"
+            output_dir = base_dir / f"output_{combined_label}_inclusive"
+
+            cmd = (
+                f"python3 {runtext2ws_path} "
+                f"--inputName Datacard_{combined_label} "
+                f"--outputDir {output_dir} "
+                f"--outputName Datacard_{combined_label} "
+                "--mode mu_fiducial "
+                "--common_opts \"-m 125.38 higgsMassRange=122,128\" "
+                "--batch local"
+            )
+            subprocess.run(cmd, shell=True, check=True)
+
+            print(f"Combined workspace created in {combined_output_dir}")
+
+        combined_label = "_".join(years)
+        config_path = config_dir / f"{combined_label}_inclusive.yml"
+
+        if config_path.exists():
+            combined_task = FinalFitsYear(
+                variable=self.variable,
+                output_dir=str(base_dir / f"output_{combined_label}_inclusive"),
+                year=combined_label,
+                unblinded_fits=self.unblinded_fits,
+                unblinded_stage_one=self.unblinded_stage_one,
+                unblinded_stage_two=self.unblinded_stage_two,
+                unblinded_stage_three=self.unblinded_stage_three,
+                unblinded_covcorr=self.unblinded_covcorr,
+                pvalue=self.pvalue,
+                asimov_fits=self.asimov_fits,
+                asimov_impacts=self.asimov_impacts,
+                asimov_covcorr=self.asimov_covcorr,
+                unblinded_diff_spectra=self.unblinded_diff_spectra,
+                asimov_diff_spectra=self.asimov_diff_spectra,
+                batch_system=self.batch_system,
+                batch_flavor=self.batch_flavor,
+            )
+
+            luigi.build([combined_task], local_scheduler=True, workers=1)
+
+        else:
+            print(f"No config found for {combined_label}_inclusive.yml, skipping combined fits.")
+
+
+
+    
+    def output(self):
+        years = [y.strip() for y in self.years.split(",") if y.strip()]
+        if len(years) < 2:
+            # No combined output for single year
+            return None
+
+        combined_label = "_".join(years)
+        combined_card_path = os.path.join(
+            os.getcwd(),
+            f"output_{combined_label}_inclusive/Combine/Datacard_{combined_label}.root"
+        )
+        return law.LocalFileTarget(combined_card_path)
+    
+    def complete(self):
+        # WrapperTasks are considered complete if all requirements are complete AND their output exists.
+        output = self.output()
+        if not output:
+            return all(req.complete() for req in law.util.flatten(self.requires()))
+        return output.exists()
+
+
+
+class FinalFitsYear(law.Task):
     variable = law.Parameter(default="", description="Variable to be used")
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     year = law.Parameter(default='2022', description="Year")
@@ -155,8 +353,10 @@ class FinalFits(law.Task):
             output_paths.append(law.LocalFileTarget(output_dir+ f"/Datacards/Datacard_{self.year}.txt"))
             
             # Background output
-            output_paths.append(law.LocalFileTarget(output_dir + f"/outdir_{background_config['ext']}"))     
-            output_paths.append(law.LocalFileTarget(output_dir + f"/outdir_{background_config['ext']}/bkgfTest-Data/fTestResults.txt"))
+            base_path = os.path.join(output_dir, "Background", f"outdir_{background_config['ext']}")
+            output_paths.append(law.LocalFileTarget(base_path))
+            output_paths.append(law.LocalFileTarget(os.path.join(base_path, "bkgfTest-Data", "fTestResults.txt")))
+
         else:
             # Signal+Datacard output
             if datacard_config['saveDataFrame']:
@@ -167,9 +367,10 @@ class FinalFits(law.Task):
             output_paths.append(law.LocalFileTarget(output_dir+ f"/Datacards/Datacard_{self.variable}_{self.year}_unsymmetrized.txt"))
             
             # Background output
-            output_paths.append(law.LocalFileTarget(output_dir + f"/outdir_{background_config['ext']}_{self.variable}"))
-            output_paths.append(law.LocalFileTarget(output_dir + f"/outdir_{background_config['ext']}_{self.variable}/bkgfTest-Data/fTestResults.txt"))
-        
+            base_path = os.path.join(output_dir, "Background", f"outdir_{background_config['ext']}_{self.variable}")
+            output_paths.append(law.LocalFileTarget(base_path))
+            output_paths.append(law.LocalFileTarget(os.path.join(base_path, "bkgfTest-Data", "fTestResults.txt")))
+ 
         if convert_boolean_string(self.unblinded_fits) or convert_boolean_string(self.unblinded_stage_three):
             output = []
             output += [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', 'scans')]


### PR DESCRIPTION
To run with combinedCards, just do e.g. --year 2022,2023,2024. The script will do the rest. Just be sure that the paths in the individual configs are correct.

You may want to try:
`law run FinalFits --year 2022,2023,2024 --workers 24 --asimov-fits True` 
or
`law run FinalFits --year 2022,2023 --workers 24 --asimov-fits True` 

1. Fix output paths (and for Nico: input paths) in the configs. 
2. Do the same for the "new" configs for combined years (e.g. 2022_2023_inclusive.yml and 2022_2023_2024_inclusive.yml ).
3. If you want to run with htcondor, fix law/htcondor_setup.sh
4. Initialise law
5. Hit e.g. `law run FinalFits --year 2022,2023,2024 --workers 24 --asimov-fits True` to get the 2022,2023,2024 combinedCards inclusive result.


I also corrected some lines, so that 2024 can be run without defining eras. + smaller fixes