### PR TITLE
fixed dependency problem of comb workflow and new logic

### DIFF
--- a/Combine/law_combine.py
+++ b/Combine/law_combine.py
@@ -476,7 +476,7 @@ class RunText2Workspace(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
             execute_command([f"xrdcp -rf {os.path.join(temp_output_dir, 'Combine', 't2w_jobs/')} root://t3dcachedb03.psi.ch:1094//{output_dir}/Combine/t2w_jobs/"], shell=True)
             shutil.rmtree(temp_output_dir)
         
-class AsimovFitCategoryFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class AsimovFitCategoryFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -1534,7 +1534,7 @@ class CreateAsimovFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow):
             
         os.chdir(cwd)
         
-class AsimovImpactFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class AsimovImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -2044,7 +2044,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
         
         os.chdir(cwd)
         
-class AsimovImpactThirdStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class AsimovImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -2324,7 +2324,7 @@ class AsimovImpactThirdStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWork
         os.chdir(cwd)
 
 
-class AsimovCovCorrHesse(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class AsimovCovCorrHesse(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -2500,7 +2500,7 @@ class AsimovCovCorrHesse(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflo
             
         os.chdir(cwd)
         
-class AsimovCovCorr(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class AsimovCovCorr(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -2704,7 +2704,7 @@ class AsimovCovCorr(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #
             
         os.chdir(cwd)
 
-class UnblindedFitSystSingle(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class UnblindedFitSystSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -3499,7 +3499,7 @@ class UnblindedFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
         
         os.chdir(cwd)
         
-class CreateUnblindedFit(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class CreateUnblindedFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -3850,7 +3850,7 @@ class UnblindedCovCorrHesse(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
             
         os.chdir(cwd)
         
-class UnblindedCovCorr(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class UnblindedCovCorr(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -4052,7 +4052,7 @@ class UnblindedCovCorr(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow)
         os.chdir(cwd)
         
         
-class UnblindedImpactFirstStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class UnblindedImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -4527,7 +4527,7 @@ class UnblindedImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Local
             
         os.chdir(cwd)
         
-class UnblindedImpactThirdStep(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class UnblindedImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -5539,7 +5539,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
         
         os.chdir(cwd)
         
-class MggDistribution(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class MggDistribution(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")
@@ -5856,7 +5856,7 @@ class MggDistribution(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow):
         os.chdir(main_dir)
         
         
-class PValueCalculation(Task, SlurmWorkflow, HTCondorWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
+class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(law.Task): #(Task, HTCondorWorkflow, law.LocalWorkflow):
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     variable = law.Parameter(default="", description="Variable to be used")
     year = law.Parameter(default='2022', description="Year")

--- a/Plots/inputs_robustHesse.json
+++ b/Plots/inputs_robustHesse.json
@@ -45,7 +45,7 @@
         "points":"",
         "fit_opts":"--saveSpecifiedNuis all --saveInactivePOI 1"
     },
-    "Njets2p5":{
+    "NJ":{
         "pois":"r_NJ_0p0_1p0,r_NJ_1p0_2p0,r_NJ_2p0_3p0,r_NJ_3p0_100p0",
         "fits":"robustHesse:syst:r_NJ_1p0_2p0",
         "points":"",

--- a/Plots/makeCorrMatrix.py
+++ b/Plots/makeCorrMatrix.py
@@ -176,7 +176,7 @@ for mode,pois in modes.items():
         label_size = 0.05
       elif mode.count("rapidity"):
         label_size = 0.06
-      elif mode.count("Njets2p5"):
+      elif mode.count("NJ"):
         label_size = 0.06
       elif mode.count("ptJ0"):
         label_size = 0.06

--- a/Plots/poi_differential_hesse_noLabels.json
+++ b/Plots/poi_differential_hesse_noLabels.json
@@ -14,7 +14,7 @@
   "r_YH_0p3_0p6":"#sigma_{[0.3,0.6)}^{fid}",
   "r_YH_0p6_0p9":"#sigma_{[0.6,0.9)}^{fid}",
   "r_YH_0p9_2p5":"#sigma_{[0.9,2.5)}^{fid}",
-  "Njets2p5":"#font[52]{N}_{Jets}",
+  "NJ":"#font[52]{N}_{Jets}",
   "r_NJ_0p0_1p0":"#sigma_{[0,1)}^{fid}",
   "r_NJ_1p0_2p0":"#sigma_{[1,2)}^{fid}",
   "r_NJ_2p0_3p0":"#sigma_{[2,3)}^{fid}",

--- a/law/analysis.py
+++ b/law/analysis.py
@@ -50,22 +50,25 @@ class FinalFits(law.WrapperTask):
 
     def requires(self):
         years = [y.strip() for y in self.years.split(",") if y.strip()]
+        multi_year = len(years) > 1  # when combining years, only force per-year datacards
+
         return [
             FinalFitsYear(
                 variable=self.variable,
                 output_dir=self.output_dir,
                 year=y,
-                unblinded_fits=self.unblinded_fits,
-                unblinded_stage_one=self.unblinded_stage_one,
-                unblinded_stage_two=self.unblinded_stage_two,
-                unblinded_stage_three=self.unblinded_stage_three,
-                unblinded_covcorr=self.unblinded_covcorr,
-                pvalue=self.pvalue,
-                asimov_fits=self.asimov_fits,
-                asimov_impacts=self.asimov_impacts,
-                asimov_covcorr=self.asimov_covcorr,
-                unblinded_diff_spectra=self.unblinded_diff_spectra,
-                asimov_diff_spectra=self.asimov_diff_spectra,
+                datacard_only=multi_year,
+                unblinded_fits=self.unblinded_fits if not multi_year else False,
+                unblinded_stage_one=self.unblinded_stage_one if not multi_year else False,
+                unblinded_stage_two=self.unblinded_stage_two if not multi_year else False,
+                unblinded_stage_three=self.unblinded_stage_three if not multi_year else False,
+                unblinded_covcorr=self.unblinded_covcorr if not multi_year else False,
+                pvalue=self.pvalue if not multi_year else False,
+                asimov_fits=self.asimov_fits if not multi_year else False,
+                asimov_impacts=self.asimov_impacts if not multi_year else False,
+                asimov_covcorr=self.asimov_covcorr if not multi_year else False,
+                unblinded_diff_spectra=self.unblinded_diff_spectra if not multi_year else False,
+                asimov_diff_spectra=self.asimov_diff_spectra if not multi_year else False,
                 batch_system=self.batch_system,
                 batch_flavor=self.batch_flavor,
             )
@@ -244,10 +247,27 @@ class FinalFits(law.WrapperTask):
             config_path = config_dir / f"{combined_label}_{self.variable}.yml"
 
         if config_path.exists():
+            combined_datacard_only = not any(
+                convert_boolean_string(flag)
+                for flag in [
+                    self.unblinded_fits,
+                    self.unblinded_stage_one,
+                    self.unblinded_stage_two,
+                    self.unblinded_stage_three,
+                    self.unblinded_covcorr,
+                    self.pvalue,
+                    self.asimov_fits,
+                    self.asimov_impacts,
+                    self.asimov_covcorr,
+                    self.unblinded_diff_spectra,
+                    self.asimov_diff_spectra,
+                ]
+            )
             combined_task = FinalFitsYear(
                 variable=self.variable,
                 output_dir=str(base_dir / f"output_{combined_label}_inclusive" if self.variable == '' else base_dir / f"output_{combined_label}_{self.variable}"),
                 year=combined_label,
+                datacard_only=combined_datacard_only,
                 unblinded_fits=self.unblinded_fits,
                 unblinded_stage_one=self.unblinded_stage_one,
                 unblinded_stage_two=self.unblinded_stage_two,
@@ -346,6 +366,7 @@ class FinalFitsYear(law.Task):
     variable = law.Parameter(default="", description="Variable to be used")
     output_dir = law.Parameter(default = '', description="Path to the output directory")
     year = law.Parameter(default='2022', description="Year")
+    datacard_only = law.Parameter(default=False, description="If True, stop after building datacards/text2workspace")
     
     # Unblinded fits and impacts
     unblinded_fits = law.Parameter(default=False, description="Produce unblinded fits")
@@ -388,6 +409,24 @@ class FinalFitsYear(law.Task):
             output_dir = config['outputFolder']
         else:
             output_dir = self.output_dir
+
+        if convert_boolean_string(self.datacard_only):
+            fitConfig = config["combine_fit"]
+            tasks["RunT2WS"] = RunText2Workspace(
+                output_dir=output_dir,
+                variable=self.variable,
+                year=self.year,
+                version=self.variable if self.variable != "" else "inclusive",
+                batch_flavor=self.batch_flavor,
+                workflow=fitConfig["execution"],
+                slurm_partition=fitConfig['batchPartition'],
+                slurm_memory=fitConfig['batchMemory'],
+                slurm_max_runtime=fitConfig['batchMaxRuntime'],
+                htcondor_partition=fitConfig['batchPartition'],
+                htcondor_memory=fitConfig['batchMemory'],
+                htcondor_max_runtime=fitConfig['batchMaxRuntime'],
+            )
+            return tasks
 
         if convert_boolean_string(self.unblinded_fits):
             tasks["CreateUnblindedFit"] = CreateUnblindedFit(variable=self.variable, output_dir=output_dir, year=self.year, batch_flavor=self.batch_flavor, version=self.variable if self.variable != "" else "inclusive", workflow=self.batch_system)
@@ -450,6 +489,17 @@ class FinalFitsYear(law.Task):
             output_dir = config['outputFolder']
         else:
             output_dir = self.output_dir
+
+        if convert_boolean_string(self.datacard_only):
+            if self.variable == '':
+                return [
+                    law.LocalFileTarget(os.path.join(output_dir, "Combine", f"Datacard_{self.year}.txt")),
+                    law.LocalFileTarget(os.path.join(output_dir, "Combine", f"Datacard_{self.year}.root")),
+                ]
+            return [
+                law.LocalFileTarget(os.path.join(output_dir, "Combine", f"Datacard_{self.variable}_{self.year}.txt")),
+                law.LocalFileTarget(os.path.join(output_dir, "Combine", f"Datacard_{self.variable}_{self.year}.root")),
+            ]
             
         datacard_config = config["datacard"]
         background_config = config["backgroundScriptCfg"] 


### PR DESCRIPTION
As described in https://github.com/JaLuka98/flashggFinalFit/issues/50 there is a problem with building the impacts of combined years, depending on the initial state of the single years. This change fixes https://github.com/JaLuka98/flashggFinalFit/issues/50 and implements a new logic.
The idea:
- `law run FinalFits --year 2022,2023` already creates the combined datacard and runs the single years until the single year runtext2workspace step. (There is no need to specify the next task already)
- `law run FinalFits --year 2022,2023 --asimov-fits True` no longer creates Asimov-fits for the single years. If one wants Asimov fits for the single years, one has to run sth like `law run FinalFits --year 2022 --asimov-fits True`
- The initial problem (from the issue) is solved. One might test this by deleting the Datacard and Combine folders of e.g. 2022 and 2023 as well as the combined year output directory and runs `law run FinalFits --year 2022,2023 --asimov-fits True --asimov-impacts True` (estimated runtime for Aachen ~45min)

For the sake of running without unintended slurm jobs (even though htcondor is specified), some changes were made for the preferred "batch-flavor"/"workflow"
After talking to JLS and NH: Njets2p5 was now changed to NJ (at least for the Hesse matrix).