### PR TITLE
Improve spectra plotting

### DIFF
--- a/Plots/Spectra/config/2022_2023_NJ.yml
+++ b/Plots/Spectra/config/2022_2023_NJ.yml
@@ -1,3 +1,5 @@
+lumi: 62.4
+
 frame1:
   custom_xtick_labels:
     - "0"

--- a/Plots/Spectra/config/2022_NJ.yml
+++ b/Plots/Spectra/config/2022_NJ.yml
@@ -1,0 +1,54 @@
+frame1:
+  custom_xtick_labels:
+    - "0"
+    - "1"
+    - "2"
+    - "3+"
+  custom_xticks:
+    - 0.5
+    - 1.5
+    - 2.5
+    - 3.5
+  ylabel:
+    text: '$\sigma_{\text{fid}}$ (fb)'
+    fontsize: 20
+  ylim:
+    bottom: 0
+  fontsize: 14
+  title_fontsize: 14
+
+frame2:
+  xtick_labels:
+    - "0"
+    - "1"
+    - "2"
+    - "3+"
+  xticks:
+    - 0.5
+    - 1.5
+    - 2.5
+    - 3.5
+  ytick_labels:
+    is_data: 
+      - "0.0"
+      - "1.0"
+      - "2.0"
+      - "3.0"
+    not_data:
+      - "0.0"
+      - "0.5"
+      - "1.0"
+      - "1.5"
+      - "2.0"
+  yticks:
+    is_data: 
+      - 0
+      - 1
+      - 2
+      - 3
+    not_data:
+      - 0
+      - 0.5
+      - 1
+      - 1.5
+      - 2

--- a/Plots/Spectra/config/2023_NJ.yml
+++ b/Plots/Spectra/config/2023_NJ.yml
@@ -1,0 +1,54 @@
+frame1:
+  custom_xtick_labels:
+    - "0"
+    - "1"
+    - "2"
+    - "3+"
+  custom_xticks:
+    - 0.5
+    - 1.5
+    - 2.5
+    - 3.5
+  ylabel:
+    text: '$\sigma_{\text{fid}}$ (fb)'
+    fontsize: 20
+  ylim:
+    bottom: 0
+  fontsize: 14
+  title_fontsize: 14
+
+frame2:
+  xtick_labels:
+    - "0"
+    - "1"
+    - "2"
+    - "3+"
+  xticks:
+    - 0.5
+    - 1.5
+    - 2.5
+    - 3.5
+  ytick_labels:
+    is_data: 
+      - "0.0"
+      - "1.0"
+      - "2.0"
+      - "3.0"
+    not_data:
+      - "0.0"
+      - "0.5"
+      - "1.0"
+      - "1.5"
+      - "2.0"
+  yticks:
+    is_data: 
+      - 0
+      - 1
+      - 2
+      - 3
+    not_data:
+      - 0
+      - 0.5
+      - 1
+      - 1.5
+      - 2

--- a/Plots/Spectra/law_spectra.py
+++ b/Plots/Spectra/law_spectra.py
@@ -430,7 +430,17 @@ class CreateDiffSpectra(law.Task):#(law.Task): #(Task, HTCondorWorkflow, law.Loc
         else:
             cms_label = "Preliminary"
         # print(args.no_preliminary, cms_label)
-        intLumi = plotting_config["lumi"] if "lumi" in plotting_config else lumiMap[f'{self.year}']
+        # Use lumi from config if available, else build it from the individual years if something like 2022_2023 is queried
+        # If that is also not the case, it is a single year, so take lumi from the map
+        if "lumi" in plotting_config:
+            intLumi = plotting_config["lumi"]
+        else:
+            year_str = str(self.year)
+            if "_" in year_str:
+                years = year_str.split("_")
+                intLumi = sum(lumiMap[y] for y in years)
+            else:
+                intLumi = lumiMap[year_str]
         hep.cms.label(cms_label, data=convert_boolean_string(self.is_unblinded), lumi=intLumi, fontsize=20, com=13.6)
 
         # Plot theoretical predictions and experimental data

--- a/Plots/Spectra/law_spectra.py
+++ b/Plots/Spectra/law_spectra.py
@@ -425,6 +425,8 @@ class CreateDiffSpectra(law.Task):#(law.Task): #(Task, HTCondorWorkflow, law.Loc
         # frame1 = fig.add_axes((.1, .35, .8, .8))
         if current_config['no_preliminary']:
             cms_label = ""
+        elif current_config['private_work']:
+            cms_label = "Private Work"
         else:
             cms_label = "Preliminary"
         # print(args.no_preliminary, cms_label)

--- a/Plots/Spectra/law_spectra.py
+++ b/Plots/Spectra/law_spectra.py
@@ -428,7 +428,8 @@ class CreateDiffSpectra(law.Task):#(law.Task): #(Task, HTCondorWorkflow, law.Loc
         else:
             cms_label = "Preliminary"
         # print(args.no_preliminary, cms_label)
-        hep.cms.label(cms_label, data=convert_boolean_string(self.is_unblinded), lumi=lumiMap[f'{self.year}'], fontsize=20, com=13.6)
+        intLumi = plotting_config["lumi"] if "lumi" in plotting_config else lumiMap[f'{self.year}']
+        hep.cms.label(cms_label, data=convert_boolean_string(self.is_unblinded), lumi=intLumi, fontsize=20, com=13.6)
 
         # Plot theoretical predictions and experimental data
         plt.stairs((ggh_xs_norm+xh_xs_norm), bins_plot, linewidth=2, label='ggH (MadGraph5_aMC@NLO + NNLOPS + Pythia) + xH', color='tab:blue')

--- a/config/2022_2023_2024_PTH.yml
+++ b/config/2022_2023_2024_PTH.yml
@@ -279,6 +279,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTH_ggH"
   vbf_xs: "fidXS_PTH_VBFH"
   vh_xs: "fidXS_PTH_VH"

--- a/config/2022_2023_NJ.yml
+++ b/config/2022_2023_NJ.yml
@@ -277,6 +277,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_NJ_ggH"
   vbf_xs: "fidXS_NJ_VBFH"
   vh_xs: "fidXS_NJ_VH"

--- a/config/2022_2023_PTH.yml
+++ b/config/2022_2023_PTH.yml
@@ -279,6 +279,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTH_ggH"
   vbf_xs: "fidXS_PTH_VBFH"
   vh_xs: "fidXS_PTH_VH"

--- a/config/2022_2023_PTJ0.yml
+++ b/config/2022_2023_PTJ0.yml
@@ -71,7 +71,8 @@ combine_mggToys:
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
 spectra:
-  no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  no_preliminary: True # Flag that determines if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTJ0_ggH"
   vbf_xs: "fidXS_PTJ0_VBFH"
   vh_xs: "fidXS_PTJ0_VH"

--- a/config/2022_2023_rapidity.yml
+++ b/config/2022_2023_rapidity.yml
@@ -72,6 +72,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_YH_ggH"
   vbf_xs: "fidXS_YH_VBFH"
   vh_xs: "fidXS_YH_VH"

--- a/config/2022_NJ.yml
+++ b/config/2022_NJ.yml
@@ -221,6 +221,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_NJ_ggH"
   vbf_xs: "fidXS_NJ_VBFH"
   vh_xs: "fidXS_NJ_VH"

--- a/config/2022_PTH.yml
+++ b/config/2022_PTH.yml
@@ -223,6 +223,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTH_ggH"
   vbf_xs: "fidXS_PTH_VBFH"
   vh_xs: "fidXS_PTH_VH"

--- a/config/2022_PTJ0.yml
+++ b/config/2022_PTJ0.yml
@@ -230,6 +230,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTJ0_ggH"
   vbf_xs: "fidXS_PTJ0_VBFH"
   vh_xs: "fidXS_PTJ0_VH"

--- a/config/2022_rapidity.yml
+++ b/config/2022_rapidity.yml
@@ -222,6 +222,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_YH_ggH"
   vbf_xs: "fidXS_YH_VBFH"
   vh_xs: "fidXS_YH_VH"

--- a/config/2023_NJ.yml
+++ b/config/2023_NJ.yml
@@ -221,6 +221,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_NJ_ggH"
   vbf_xs: "fidXS_NJ_VBFH"
   vh_xs: "fidXS_NJ_VH"

--- a/config/2023_PTH.yml
+++ b/config/2023_PTH.yml
@@ -220,6 +220,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTH_ggH"
   vbf_xs: "fidXS_PTH_VBFH"
   vh_xs: "fidXS_PTH_VH"

--- a/config/2023_PTJ0.yml
+++ b/config/2023_PTJ0.yml
@@ -221,6 +221,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTJ0_ggH"
   vbf_xs: "fidXS_PTJ0_VBFH"
   vh_xs: "fidXS_PTJ0_VH"

--- a/config/2023_rapidity.yml
+++ b/config/2023_rapidity.yml
@@ -222,6 +222,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_YH_ggH"
   vbf_xs: "fidXS_YH_VBFH"
   vh_xs: "fidXS_YH_VH"

--- a/config/2024_PTH.yml
+++ b/config/2024_PTH.yml
@@ -191,6 +191,7 @@ combine_mggToys:
 
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
   ggh_xs: "fidXS_PTH_ggH"
   vbf_xs: "fidXS_PTH_VBFH"
   vh_xs: "fidXS_PTH_VH"

--- a/law/analysis.py
+++ b/law/analysis.py
@@ -661,6 +661,15 @@ class FinalFitsYear(law.Task):
 
             for _, current_output_path in enumerate(output):
                 output_paths.append(law.LocalFileTarget(current_output_path))
+        
+        if self.variable != '':
+            spectra_dir = os.path.join(output_dir, 'Combine', fitFolderName)
+            if convert_boolean_string(self.asimov_diff_spectra):
+                output_paths.append(law.LocalFileTarget(os.path.join(spectra_dir, 'spectra_blinded.pdf')))
+                output_paths.append(law.LocalFileTarget(os.path.join(spectra_dir, 'spectra_blinded.png')))
+            if convert_boolean_string(self.unblinded_diff_spectra):
+                output_paths.append(law.LocalFileTarget(os.path.join(spectra_dir, 'spectra.pdf')))
+                output_paths.append(law.LocalFileTarget(os.path.join(spectra_dir, 'spectra.png')))
 
         if convert_boolean_string(self.asimov_impacts):
         


### PR DESCRIPTION
- Adding 2022 2023 PTH yml spectra config
- Adding option to use lumi from config instead of CommonObjects
- Adding missing spectra targets to FinalFitsYear.output() so that the tasks now expect the plots to be present before reporting completion. This should prevent Luigi from skipping the CreateDiffSpectra when datacards already exist and no spectra have been built yet