### PR TITLE
Correctly reflect number of LHEPDF weights in 4FS samples

### DIFF
--- a/Signal/law_signal.py
+++ b/Signal/law_signal.py
@@ -990,7 +990,7 @@ class SignalPackagingCategory(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWo
                 else:
                     slurm_copy_command = [
                         'xrdcp', '-rf',
-                        'root://t3dcachedb03.psi.ch:1094//'+f"{self.output_dir}/outdir_{signalScriptCfg['ext']}",
+                        'root://t3dcachedb03.psi.ch:1094//'+f"{self.output_dir}/outdir_{currentConfig['ext']}",
                         f"{os.environ['TARGET_PATH']}/"
                     ]
                 print(slurm_copy_command)

--- a/Signal/law_signal.py
+++ b/Signal/law_signal.py
@@ -380,7 +380,7 @@ class CalcPhotonSystCategory(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             if "/work" in self.output_dir:
                 execute_command([f'mkdir -p {self.output_dir}/outdir_{self.ext}/calcPhotonSyst/pkl'], shell=True)
             else:   
-                execute_command([f'xrdfs root://t3dcachedb03.psi.ch:1094/ mkdir -p {self.output_dir}/calcPhotonSyst/pkl'], shell=True)
+                execute_command([f'xrdfs root://t3dcachedb03.psi.ch:1094/ mkdir -p {self.output_dir}/outdir_{self.ext}/calcPhotonSyst/pkl'], shell=True)
 
             os.environ["TARGET_PATH"] = f"/scratch/{os.environ['USER']}/{os.environ['SLURM_JOB_ID']}"
             execute_command([f'mkdir -p $TARGET_PATH/outdir_{self.ext}/calcPhotonSyst/pkl'], shell=True)
@@ -664,8 +664,8 @@ class SignalFitCategoryProcess(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 execute_command([f'mkdir -p {self.output_dir}/outdir_{self.ext}/signalFit/output'], shell=True)
                 execute_command([f'mkdir -p {self.output_dir}/outdir_{self.ext}/signalFit/Plots'], shell=True)
             else:   
-                execute_command([f'xrdfs root://t3dcachedb03.psi.ch:1094/ mkdir -p {self.output_dir}/signalFit/output'], shell=True)
-                execute_command([f'xrdfs root://t3dcachedb03.psi.ch:1094/ mkdir -p {self.output_dir}/signalFit/Plots'], shell=True)
+                execute_command([f'xrdfs root://t3dcachedb03.psi.ch:1094/ mkdir -p {self.output_dir}/outdir_{self.ext}/signalFit/output'], shell=True)
+                execute_command([f'xrdfs root://t3dcachedb03.psi.ch:1094/ mkdir -p {self.output_dir}/outdir_{self.ext}/signalFit/Plots'], shell=True)
 
             os.environ["TARGET_PATH"] = f"/scratch/{os.environ['USER']}/{os.environ['SLURM_JOB_ID']}"
             execute_command([f'mkdir -p $TARGET_PATH/outdir_{self.ext}/signalFit/output'], shell=True)

--- a/Trees2WS/law_trees2ws.py
+++ b/Trees2WS/law_trees2ws.py
@@ -102,7 +102,7 @@ class Trees2WSSingleProcess(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
         productionMode = current_mode_proc_mass[0]
         input_mass = current_mode_proc_mass[1]
         input_path = current_mode_proc_mass[2]
-               
+
         apply_mass_cut = convert_boolean_string(self.apply_mass_cut)
         doNNLOPS = convert_boolean_string(self.doNNLOPS)
         doSystematics = convert_boolean_string(self.doSystematics)
@@ -173,7 +173,9 @@ class Trees2WSSingleProcess(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
         productionMode = current_mode_proc_mass[0]
         input_mass = current_mode_proc_mass[1]
         input_path = current_mode_proc_mass[2]
-        
+
+        isFourFlavorScheme = (productionMode in fourFlavorSamples)
+
         apply_mass_cut = convert_boolean_string(self.apply_mass_cut)
         doNNLOPS = convert_boolean_string(self.doNNLOPS)
         doSystematics = convert_boolean_string(self.doSystematics)
@@ -213,10 +215,12 @@ class Trees2WSSingleProcess(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 stxsVar          = config['stxsVar']
                 diffVar          = config['diffVar']
                 systematicsVars  = config['systematicsVars']
-                theoryWeightContainers = config['theoryWeightContainers']
+                if isFourFlavorScheme: 
+                    theoryWeightContainers = config['theoryWeightContainers']['4FS']
+                else:
+                    theoryWeightContainers = config['theoryWeightContainers']['5FS']
                 systematics      = config['systematics']
                 cats             = config['cats']
-
 
             else:
                 print( "[ERROR] %s config file does not exist. Leaving..."%input_config)

--- a/commonTools/commonObjects.py
+++ b/commonTools/commonObjects.py
@@ -131,6 +131,7 @@ production_XS = {
 }
 
 short_production_modes = ["ggh", "vbf", "vh", "tth", "bbh"]
+fourFlavorSamples = ["bbh"] # Use short notation
 
 eft_variables = ["chg", "chb", "chw", "chwb", "chbox", "chd", "chl3", "cll1", "ctbre", "cthre", "ctwre"]
 

--- a/config/2022_2023_2024_PTH.yml
+++ b/config/2022_2023_2024_PTH.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenPTH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_2023_2024_inclusive.yml
+++ b/config/2022_2023_2024_inclusive.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
   # Do empty dict, only this way it works
   # theoryWeightContainers: {}
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_2023_NJ.yml
+++ b/config/2022_2023_NJ.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenNJ"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_2023_PTH.yml
+++ b/config/2022_2023_PTH.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenPTH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_2023_inclusive.yml
+++ b/config/2022_2023_inclusive.yml
@@ -55,8 +55,12 @@ trees2wsCfg:
   # Do empty dict, only this way it works
   # theoryWeightContainers: {}
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_DPhiJ0J1.yml
+++ b/config/2022_DPhiJ0J1.yml
@@ -1,21 +1,30 @@
 # Config file: options for signal fitting
 
-outputFolder: '/net/data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2023_PTJ0'
+# outputFolder: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_06_12/intermediateRun3/finalfits/DPhiJ0J1'
+# outputFolder: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_06_powheg/finalfits/DPhiJ0J1'
+# outputFolder: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_10_14_intermediate/finalfits_postBPix/DPhiJ0J1_getCorrectCorrelations'
+outputFolder: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_16/earlyRun3/finalfits/DPhiJ0J1_RandomizeAux_separateDatasets/'
+
 
 inputFiles:
-  # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_11_13/ptJ0/2023/data/allData_2023.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_11_13/ptJ0/2023/signal/'
+  Trees2WSData: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_16/earlyRun3/variables/DPhiJ0J1/allData_2022.root'
+  Trees2WS: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_16/earlyRun3/variables/DPhiJ0J1/root'
+  catDict_timestamp: '2025_10_31'
+
+  mc_src_files: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_22/earlyRun3/signal'
+  powheg_src_files: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_22/earlyRun3_powheg/signal' 
+  bkg_src_files: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/Background/2022/2025_10_29'
+  data_src_files: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_16/earlyRun3/data'
 
 backgroundScriptCfg:
   # Setup
   cats: 'auto' # auto: automatically inferred from input ws
   catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
-  ext: 'Run3FidXSAnalysis_PTJ0' # extension to add to output directory
-  # year: '2023' # Use combined when merging all years in category (for plots)
-  execution: 'htcondor'
+  ext: 'Run3FidXSAnalysis_DPhiJ0J1' # extension to add to output directory
+  # year: '2022' # Use combined when merging all years in category (for plots)
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
-  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMemory: 14000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
 trees2wsCfg:
@@ -37,21 +46,21 @@ trees2wsCfg:
     - "*Up"
     - "*Down"
     - "fiducialGeometricFlag"
-    - "diffVariable_GenPTJ0"
+    - "diffVariable_GenDPhiJ0J1"
   
   dataVars:
     - "CMS_hgg_mass"
     - "weight" # Vars to be added for data
     
   stxsVar: ''
-  diffVar: 'diffVariable_GenPTJ0'
+  diffVar: 'diffVariable_GenDPhiJ0J1'
   notagVars: [] # Vars to add to NOTAG RooDataset
   
   systematicsVars:
     - "CMS_hgg_mass"
     - "weight"
     - "fiducialGeometricFlag"
-    - "diffVariable_GenPTJ0"
+    - "diffVariable_GenDPhiJ0J1"
   
   theoryWeightContainers:
     4FS:
@@ -65,6 +74,7 @@ trees2wsCfg:
   systematics:
     - "ScaleEB"
     - "ScaleEE"
+    # - "Scale"
     - "Smearing"
     - "Material"
     - "FNUF"
@@ -74,73 +84,76 @@ trees2wsCfg:
 
   cats: 'auto'
 
-  execution: 'htcondor'
-  batchPartition: "short" # Slurm partition to use for job submission
-  batchMemory: 4000 # Slurm memory to use for job submission
-  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+  execution: 'slurm'
+  batchPartition: "standard" # Slurm partition to use for job submission
+  batchMemory: 14000 # Slurm memory to use for job submission
+  batchMaxRuntime: "05:00:00" # Slurm max runtime to use
 
-signalScriptCfg_2023_preBPix:
+signalScriptCfg_2022_preEE:
   # Setup
   procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
   cats: 'auto' # if auto: inferred automatically from (0) workspace
-  ext: 'Run3FidXSAnalysis_PTJ0_2023preBPix' # output directory extension
-  analysisRM: 'Run3FidXSAnalysisPTJ0' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  ext: 'Run3FidXSAnalysis_DPhiJ0J1_2022preEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisDPhiJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
   analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
-  year: '2023preBPix' # Use 'combined' if merging all years: not recommended
+  year: '2022preEE' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '25' # 50
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
-  replacementThreshold: '50'
+
   # Photon shape systematics  
   scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  # scales: 'Scale' # separate nuisance per year
   scalesCorr: 'FNUF,Material' # correlated across years
   scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
   smears: 'Smearing' # separate nuisance per year
 
   doPlots: True
 
-  beamspotWidthData: '3.703'
-  beamspotWidthMC: '3.597'
+  beamspotWidthData: '3.2'
+  beamspotWidthMC: '3.732'
 
 
   # Job submission options
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
-signalScriptCfg_2023_postBPix:
+signalScriptCfg_2022_postEE:
   # Setup
   procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
   cats: 'auto' # if auto: inferred automatically from (0) workspace
-  ext: 'Run3FidXSAnalysis_PTJ0_2023postBPix' # output directory extension
-  analysisRM: 'Run3FidXSAnalysisPTJ0' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  ext: 'Run3FidXSAnalysis_DPhiJ0J1_2022postEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisDPhiJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
   analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
-  year: '2023postBPix' # Use 'combined' if merging all years: not recommended
+  year: '2022postEE' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '25' # 50
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
-  replacementThreshold: '50'
+
   # Photon shape systematics  
   scales: 'ScaleEE,ScaleEB' # separate nuisance per year
+  # scales: 'Scale' # separate nuisance per year
   scalesCorr: 'FNUF,Material' # correlated across years
   scalesGlobal: 'NonLinearity,Geant4' # affect all processes equally, correlated across years
   smears: 'Smearing' # separate nuisance per year
 
   doPlots: True
 
-  
-  beamspotWidthData: '3.737'
-  beamspotWidthMC: '3.597'
+  beamspotWidthData: '3.5'
+  beamspotWidthMC: '3.732'
 
   # Job submission options
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
-packaged_2023:
+packaged_2022:
   cats: 'auto' # if auto: inferred automatically from (0) workspace
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
   mergeYears: True # Merges the eras
   ext: ''
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -149,9 +162,9 @@ datacard_yields:
   cats: 'auto' # if auto: inferred automatically from (0) workspace
   procs: 'auto' # if auto: inferred automatically from (0) workspace
   ext: 'Run3FidXSAnalysis' # Extension for saving
-  # inputWSDirMap: '2023preBPix,2023postBPix'
-  sigModelWSDir: './Models_PTJ0/signal' # Input signal model WS directory
-  bkgModelWSDir: './Models_PTJ0/background' # Input background model WS directory
+  # inputWSDirMap: '2022preEE,2022postEE'
+  sigModelWSDir: './Models_DPhiJ0J1/signal' # Input signal model WS directory
+  bkgModelWSDir: './Models_DPhiJ0J1/background' # Input background model WS directory
   bkgModelExt: 'multipdf' # Extension used when saving background model
   doSystematics: True # Include systematics calculations and add to datacard
   mergeYears: True # Merge category across years
@@ -160,11 +173,11 @@ datacard_yields:
   mass: '125' # Input workspace mass
   skipBkg: False # Only add signal processes to datacard
   bkgScaler: 1. # Add overall scale factor for background
-  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
-  execution: 'htcondor'
-  batchPartition: "short" # Slurm partition to use for job submission
+  skipCOWCorr: False # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
+  execution: 'slurm'
+  batchPartition: "standard" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
-  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+  batchMaxRuntime: "03:00:00" # Slurm max runtime to use
 
 datacard:
   # For pruning processes
@@ -174,7 +187,7 @@ datacard:
   analysis: 'Run3FidXSAnalysis' # Analysis extension: required for doTrueYield (see ./tools/XSBR.py for example)
 
   # For yield/systematics:
-  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance
+  skipCOWCorr: False # Skip centralObjectWeight correction for events in acceptance
   doSystematics: True # Include systematics calculations and add to datacard
   doMCStatUncertainty: True # Add uncertainty for MC stats
   doSTXSMerging: False # Calculate additional migrations uncertainties for merged STXS bins (for 'mnorm' tier in systematics)
@@ -182,7 +195,7 @@ datacard:
 
   # For output:
   saveDataFrame: False # Save final dataframe as pkl file
-  output: 'Datacard_PTJ0_2023' # Datacard name
+  output: 'Datacard_DPhiJ0J1_2022' # Datacard name
 
 datacard_clean:
   factor: 10000 # Factor beyond which uncertainty is considered incorrect and is removed
@@ -191,25 +204,32 @@ datacard_clean:
   symmetrizeNuisance: 'CMS_hgg_SigmaEOverEShift,CMS_hgg_scale_0_shape,CMS_hgg_scale_1_shape,CMS_hgg_scale_3_shape' # Symmetrizes asymmetric nuisance. Enter in the format nuisance1,nuisance2,nuisance3,etc.
   verbose: False # Spit out all the cleaning being done
 
+allReplicaGeneration:
+  execution: 'slurm'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 10000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
 combine_fit:
-  asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
+  asimov_numPoints: 200 # Number of points the Asimov generator should generate for the NLL scan
   unblindedFit_numPoints: 100 
   setParameterRange: "r=0,3"
-  execution: 'htcondor'
+  cminApproxPreFitTolerance: 0.01
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
-  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+  batchMaxRuntime: "00:45:00" # Slurm max runtime to use
 
 combine_impacts:
   exclude: "" # Nuisances that should be excluded from the impact computation
   not_show_POI: True
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
 combine_hesse:
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -218,28 +238,35 @@ combine_mggToys:
   nToys: 1000 # Number of toys = nToys * 10
   loadSnapshot: 'MultiDimFit'
   doBands: True
-  execution: 'htcondor'
+  execution: 'local'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
+combine_SplusB_toys:
+  execution: 'slurm'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 11000 # Slurm memory to use for job submission
+  batchMaxRuntime: "00:30:00" # Slurm max runtime to use
+
 spectra:
   no_preliminary: True # Flag that determines, if Preliminary label should be printed.
-  private_work : False
-  ggh_xs: "fidXS_PTJ0_ggH"
-  vbf_xs: "fidXS_PTJ0_VBFH"
-  vh_xs: "fidXS_PTJ0_VH"
-  tth_xs: "fidXS_PTJ0_ttH"
-  xh_xs: "fidXS_PTJ0_xH"
-  ggh_powheg_xs: "fidXS_PTJ0_ggH_powheg"
-  ggh_no_nnlops_xs: "fidXS_PTJ0_ggH_genWeight"
-  underflow_bin_normalized: True # Underflow bin normalized with binwidth
-  last_bin_center: 300
-  first_bin_center: 15
+  ggh_xs: "fidXS_DPhiJ0J1_ggH"
+  vbf_xs: "fidXS_DPhiJ0J1_VBFH"
+  vh_xs: "fidXS_DPhiJ0J1_VH"
+  tth_xs: "fidXS_DPhiJ0J1_ttH"
+  xh_xs: "fidXS_DPhiJ0J1_xH"
+  ggh_powheg_xs: "fidXS_DPhiJ0J1_ggH_powheg"
+  ggh_no_nnlops_xs: "fidXS_DPhiJ0J1_ggH_genWeight"
+  underflow_bin_normalized: False # Underflow bin normalized with binwidth
+  last_bin_center: 425
+  first_bin_center: 7.5
   plot_log: 1
-  variable: "p_{T}^{j_{1}}"
+  variable: "p_T^H"
   y_unit: "(fb/GeV)"
   x_unit: "(GeV)"
-  x_lim: [0, 400]
-  y_lim: [-0.5,2.5]
-  y_lim_top: 250
+  x_lim: [0, 500]
+  y_lim: [-1,3]
+  y_lim_top: 500
+  overflow: 500
+

--- a/config/2022_NJ.yml
+++ b/config/2022_NJ.yml
@@ -1,11 +1,11 @@
 # Config file: options for signal fitting
 
-outputFolder: '/.automount/net_rw/net__data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/output_2022_NJ/'
+outputFolder: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_16/earlyRun3/finalfits/NJ_LHEPdfFixed'
 
 inputFiles:
   # Trees2WS
-  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_11_13/Njets2p5/2022/data/allData_2022.root'
-  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2025_11_13/Njets2p5/2022/signal/'
+  Trees2WSData: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_16/earlyRun3/variables/NJ/allData_2022.root'
+  Trees2WS: '/pnfs/psi.ch/cms/trivcat/store/user/niharrin/ntuples/midRun3/samples/2025_09_16/earlyRun3/variables/NJ/root/'
 
 backgroundScriptCfg:
   # Setup
@@ -13,7 +13,7 @@ backgroundScriptCfg:
   catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
   ext: 'Run3FidXSAnalysis_NJ' # extension to add to output directory
   # year: '2022' # Use combined when merging all years in category (for plots)
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenNJ"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:
@@ -70,9 +74,9 @@ trees2wsCfg:
 
   cats: 'auto'
 
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
-  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMemory: 12000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
 signalScriptCfg_2022_preEE:
@@ -98,7 +102,7 @@ signalScriptCfg_2022_preEE:
 
 
   # Job submission options
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use 
@@ -126,7 +130,7 @@ signalScriptCfg_2022_postEE:
   beamspotWidthMC: '3.732'
 
   # Job submission options
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -136,7 +140,7 @@ packaged_2022:
   massPoints: '120,125,130' # You can now run with a single mass point if necessary
   mergeYears: True # Merges the eras
   ext: ''
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -157,7 +161,7 @@ datacard_yields:
   skipBkg: False # Only add signal processes to datacard
   bkgScaler: 1. # Add overall scale factor for background
   skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -191,7 +195,7 @@ combine_fit:
   asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
   unblindedFit_numPoints: 100 
   setParameterRange: "r=0,3"
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -199,13 +203,13 @@ combine_fit:
 combine_impacts:
   exclude: "" # Nuisances that should be excluded from the impact computation
   not_show_POI: True
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
 
 combine_hesse:
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use
@@ -214,7 +218,7 @@ combine_mggToys:
   nToys: 1000 # Number of toys = nToys * 10
   loadSnapshot: 'MultiDimFit'
   doBands: True
-  execution: 'htcondor'
+  execution: 'slurm'
   batchPartition: "short" # Slurm partition to use for job submission
   batchMemory: 4000 # Slurm memory to use for job submission
   batchMaxRuntime: "01:00:00" # Slurm max runtime to use

--- a/config/2022_PTH.yml
+++ b/config/2022_PTH.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenPTH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_PTJ0.yml
+++ b/config/2022_PTJ0.yml
@@ -55,8 +55,12 @@ trees2wsCfg:
     - "diffVariable_GenPTJ0"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_inclusive.yml
+++ b/config/2022_inclusive.yml
@@ -52,8 +52,12 @@ trees2wsCfg:
     - "fiducialGeometricFlag"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2022_rapidity.yml
+++ b/config/2022_rapidity.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenYH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2023_NJ.yml
+++ b/config/2023_NJ.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenNJ"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2023_PTH.yml
+++ b/config/2023_PTH.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenPTH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2023_inclusive.yml
+++ b/config/2023_inclusive.yml
@@ -55,8 +55,12 @@ trees2wsCfg:
   # Do empty dict, only this way it works
   #theoryWeightContainers: {}
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2023_rapidity.yml
+++ b/config/2023_rapidity.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenYH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2024_PTH.yml
+++ b/config/2024_PTH.yml
@@ -53,8 +53,12 @@ trees2wsCfg:
     - "diffVariable_GenPTH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2024_inclusive.yml
+++ b/config/2024_inclusive.yml
@@ -52,8 +52,12 @@ trees2wsCfg:
     - "fiducialGeometricFlag"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2223_NJ.yml
+++ b/config/2223_NJ.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenNJ"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2223_PTH.yml
+++ b/config/2223_PTH.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenPTH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2223_PTJ0.yml
+++ b/config/2223_PTJ0.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenPTJ0"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2223_inclusive.yml
+++ b/config/2223_inclusive.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
   # Do empty dict, only this way it works
   # theoryWeightContainers: {}
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:

--- a/config/2223_rapidity.yml
+++ b/config/2223_rapidity.yml
@@ -54,8 +54,12 @@ trees2wsCfg:
     - "diffVariable_GenYH"
   
   theoryWeightContainers:
-    weight_LHEPdf: 101
-    weight_LHEScale: 9
+    4FS:
+      weight_LHEPdf: 99
+      weight_LHEScale: 9
+    5FS:
+      weight_LHEPdf: 101
+      weight_LHEScale: 9
 
   # List of systematics: use string YEAR for year-dependent systematics
   systematics:


### PR DESCRIPTION
This pull request introduces support for distinguishing between four-flavor and five-flavor schemes in theoretical weight handling, updates configuration files to reflect this, and makes improvements to job submission settings across several config files. The changes ensure proper selection of theory weights for different production modes, especially for `bbh`, and standardize job execution to use Slurm. Additionally, a new configuration file for the `DPhiJ0J1` analysis is added.

**Flavor scheme support and theory weights:**
* Introduced `fourFlavorSamples` (with `"bbh"` as a member) in `commonTools/commonObjects.py` to identify four-flavor scheme samples.
* Logic added in `Trees2WS/law_trees2ws.py` to select the correct theory weight containers (`4FS` or `5FS`) based on the production mode, ensuring that `bbh` uses four-flavor weights. [[1]](diffhunk://#diff-85c12a4c597d1ce99f4d9079e355c42fd2fc729133d0351cfca7e5cc28d761a4R177-R178) [[2]](diffhunk://#diff-85c12a4c597d1ce99f4d9079e355c42fd2fc729133d0351cfca7e5cc28d761a4L216-L220)
* Updated all relevant config files (`2022_2023_2024_PTH.yml`, `2022_2023_2024_inclusive.yml`, `2022_2023_NJ.yml`, `2022_2023_PTH.yml`, `2022_2023_inclusive.yml`, `2022_NJ.yml`, and newly added `2022_DPhiJ0J1.yml`) to define both `4FS` and `5FS` theory weight containers under `theoryWeightContainers`. [[1]](diffhunk://#diff-391a54084eb3709468e0818aea6f960f6bae1ce94e42a163b88e174d27dd1ae2R57-R60) [[2]](diffhunk://#diff-a8f45fefaf79404be79d3a83723a4ca26ca584eab8d3fa15ba5c4b84cd950b91R57-R60) [[3]](diffhunk://#diff-dbc426cea8c5b06ee3e234d06922cc62e9d6e6e5ab4048ad39bbbac5ad639215R57-R60) [[4]](diffhunk://#diff-bc6c1a3a91a5da98df1744ed99f1c7fc7e2a801c5c537b9fc901158c5cb21765R57-R60) [[5]](diffhunk://#diff-7720f09cb8fb34430c1b0033e318297093f51e3415fc1bdb1d5e54b4b3364dfcR58-R61) [[6]](diffhunk://#diff-699ca639a836435103c62efa12c04eedeafa56e48208c6d69aff98f3d44bd66aR57-R60) [[7]](diffhunk://#diff-bad04e682772b04d57379e94143fc2715c7ed13b9109a36dcd68979cca75138eR1-R272)

**Job submission improvements:**
* Standardized job submission in config files to use Slurm instead of HTCondor, including increased memory allocation for some jobs and updated execution settings for all relevant stages (background, signal, datacard, combine). [[1]](diffhunk://#diff-699ca639a836435103c62efa12c04eedeafa56e48208c6d69aff98f3d44bd66aL73-R79) [[2]](diffhunk://#diff-699ca639a836435103c62efa12c04eedeafa56e48208c6d69aff98f3d44bd66aL101-R105) [[3]](diffhunk://#diff-699ca639a836435103c62efa12c04eedeafa56e48208c6d69aff98f3d44bd66aL129-R133) [[4]](diffhunk://#diff-699ca639a836435103c62efa12c04eedeafa56e48208c6d69aff98f3d44bd66aL139-R143) [[5]](diffhunk://#diff-699ca639a836435103c62efa12c04eedeafa56e48208c6d69aff98f3d44bd66aL160-R164) [[6]](diffhunk://#diff-699ca639a836435103c62efa12c04eedeafa56e48208c6d69aff98f3d44bd66aL194-R212) Fc226e09R1)

**Other code improvements:**
* Fixed a variable reference in the Slurm copy command in `Signal/law_signal.py` to correctly use `currentConfig['ext']` instead of `signalScriptCfg['ext']`.

**New analysis configuration:**
* Added a new config file `2022_DPhiJ0J1.yml` for the DPhiJ0J1 analysis, including all relevant settings for input files, job submission, theory weights, systematics, datacard generation, and plotting.