### PR TITLE
Fallback args for pvalue

### DIFF
--- a/Combine/law_combine.py
+++ b/Combine/law_combine.py
@@ -6112,6 +6112,7 @@ class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
                 "--X-rtd", "MINIMIZER_multiMin_hideConstants",
                 "--X-rtd", "MINIMIZER_multiMin_maskConstraints",
                 "--X-rtd", "MINIMIZER_multiMin_maskChannels=2",
+                "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Simplex,0:0.1",
                 "--cminFallbackAlgo", "Minuit2,Combined,0:0.1",
                 "--freezeParameters", "MH",

--- a/Combine/law_combine.py
+++ b/Combine/law_combine.py
@@ -6099,7 +6099,6 @@ class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
                     
         # Define the file to check
         pvalue_file = os.path.join(temp_output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombine.pvalue.MultiDimFit.mH125.38.root')
-
         # Check if the file exists
         if not os.path.isfile(pvalue_file):
             print("The pvalue file does not exist in the current directory. Creating it...")
@@ -6113,13 +6112,14 @@ class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
                 "--X-rtd", "MINIMIZER_multiMin_hideConstants",
                 "--X-rtd", "MINIMIZER_multiMin_maskConstraints",
                 "--X-rtd", "MINIMIZER_multiMin_maskChannels=2",
+                "--cminFallbackAlgo", "Minuit2,Simplex,0:0.1",
+                "--cminFallbackAlgo", "Minuit2,Combined,0:0.1",
                 "--freezeParameters", "MH",
                 "--fixedPointPOIs", f"{','.join(combineVariableDict[f'{self.year}'][f'{self.variable}']['paramStr'])},MH=125.38",
                 "-n", ".pvalue",
                 "-m", "125.38",
                 "--saveWorkspace"
             ]
-            # print(command)
             try:
                 result = subprocess.run(command, check=True, text=True, capture_output=True)
                 print("Script output:", result.stdout)


### PR DESCRIPTION
This pull request makes small updates to the `Combine/law_combine.py` script, specifically within the `run` method. The changes focus on improving the robustness of the fitting procedure by adding fallback minimizer algorithms and include minor code cleanup.

- Fitting procedure enhancements:
  * Added two `--cminFallbackAlgo` options (`Minuit2,Simplex,0:0.1` and `Minuit2,Combined,0:0.1`) to the command arguments, which provide fallback minimizer algorithms in case the default minimization fails.

- Code cleanup:
  * Removed an unnecessary blank line before the file existence check for `pvalue_file`.
  * Removed a commented-out `print(command)` statement to tidy up the code.