### PR TITLE
Add inclusive plotting helper scripts

### DIFF
--- a/Plots/makeSplusBModelPlot.py
+++ b/Plots/makeSplusBModelPlot.py
@@ -54,6 +54,7 @@ def get_options():
   parser.add_option("--problematicCats", dest="problematicCats", default='', help='Problematic analysis categories to skip when processing all')
   parser.add_option("--doHHMjjFix", dest="doHHMjjFix", default=False, action="store_true", help="Do fix for HH analysis where some cats have different Mjj var")
   parser.add_option("--POI", dest="POI", default='', help="POI to be considered.")
+  parser.add_option("--lumiLabel", dest="lumiLabel", default="61.9 fb^{-1} (13.6 TeV)", help="Luminosity label")
   return parser.parse_args()
 (opt,args) = get_options()
 

--- a/Plots/plottingTools.py
+++ b/Plots/plottingTools.py
@@ -238,7 +238,7 @@ def makeSplusBPlot(workspace,hD,hSB,hB,hS,hDr,hBr,hSr,cat,options,dB=None,reduce
   lat0.DrawLatex(0.12,0.92,"#bf{CMS} #it{Preliminary}")
   #lat0.DrawLatex(0.12,0.92,"#bf{CMS}")
   #lat0.DrawLatex(0.6,0.92,"137 fb^{-1} (13 TeV)")
-  lat0.DrawLatex(0.565,0.92,"61.9 fb^{-1} (13.6 TeV)")
+  lat0.DrawLatex(0.565,0.92,options.lumiLabel)
   lat0.DrawLatex(0.6,0.8,"#scale[0.6]{%s}"%Translate(cat,translateCats))
   #lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H#rightarrow#gamma#gamma}")
   lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H #rightarrow #gamma#gamma, m_{H} = 125.38 GeV}")

--- a/Signal/RunPlotter.py
+++ b/Signal/RunPlotter.py
@@ -9,6 +9,8 @@ from commonTools import *
 from commonObjects import *
 from plottingTools import *
 
+swd__ = os.environ.get("RUNPLOTTER_SIGNAL_DIR", swd__)
+
 def get_options():
   parser = OptionParser()
   parser.add_option('--procs', dest='procs', default='all', help="Comma separated list of processes to include. all = sum all signal procs")  

--- a/Signal/run_inclusive_mass_resolution_plots.py
+++ b/Signal/run_inclusive_mass_resolution_plots.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SIGNAL_DIR = ROOT / "Signal"
+
+CONFIGS = {
+    "2022": ROOT / "config/2022_inclusive.yml",
+    "2023": ROOT / "config/2023_inclusive.yml",
+    "2024": ROOT / "config/2024_inclusive.yml",
+    "2022_2023_2024": ROOT / "config/2022_2023_2024_inclusive.yml",
+}
+
+PLOT_YEARS = {
+    "2022": ["2022preEE", "2022postEE", "2022preEE,2022postEE"],
+    "2023": ["2023preBPix", "2023postBPix", "2023preBPix,2023postBPix"],
+    "2024": ["2024"],
+    "2022_2023_2024": ["2022preEE,2022postEE,2023preBPix,2023postBPix,2024"],
+}
+
+CATEGORIES = {
+    "best": "best_resolution=cat0",
+    "medium": "medium_resolution=cat1",
+    "worst": "worst_resolution=cat2",
+    "all": "all",
+}
+
+CATEGORY_LABELS = {
+    "best_resolution": "Best resolution",
+    "medium_resolution": "Medium resolution",
+    "worst_resolution": "Worst resolution",
+}
+
+LABEL = "Simulation Preliminary"
+DO_FWHM = False
+MAX_WORKERS = 8
+
+
+def read_config(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def packaged_file(config, label, cat):
+    output_dir = Path(config["outputFolder"].rstrip("/"))
+    ext = config[f"packaged_{label}"].get("ext", "")
+    return output_dir / f"outdir_packaged{ext}" / f"CMS-HGG_sigfit_packaged{ext}_{cat}.root"
+
+
+def rooiter(items):
+    iterator = items.iterator()
+    item = iterator.Next()
+    while item:
+        yield item
+        item = iterator.Next()
+
+
+def import_workspace_objects(output_file, input_files):
+    import ROOT
+
+    output_workspace = ROOT.RooWorkspace("wsig_13TeV", "wsig_13TeV")
+    workspace_import = getattr(output_workspace, "import")
+
+    for input_file in input_files:
+        root_file = ROOT.TFile.Open(str(input_file))
+        workspace = root_file.Get("wsig_13TeV")
+
+        for item in rooiter(workspace.allVars()):
+            workspace_import(item, ROOT.RooFit.RecycleConflictNodes(), ROOT.RooFit.Silence())
+
+        for item in rooiter(workspace.allFunctions()):
+            workspace_import(item, ROOT.RooFit.RecycleConflictNodes(), ROOT.RooFit.Silence())
+
+        for item in rooiter(workspace.allPdfs()):
+            workspace_import(item, ROOT.RooFit.RecycleConflictNodes(), ROOT.RooFit.Silence())
+
+        for item in workspace.allData():
+            workspace_import(item)
+
+        root_file.Close()
+
+    output_root = ROOT.TFile(str(output_file), "RECREATE")
+    output_workspace.Write()
+    output_root.Close()
+
+
+def make_runplotter_inputs(label, config):
+    ext = f"inclusive_mass_resolution_{label}"
+    output_dir = Path(config["outputFolder"].rstrip("/"))
+    outdir = output_dir / f"outdir_{ext}"
+    outdir.mkdir(parents=True, exist_ok=True)
+    category_labels = outdir / "category_labels.json"
+
+    with open(category_labels, "w") as f:
+        json.dump(CATEGORY_LABELS, f, indent=2)
+
+    for cat in ["cat0", "cat1", "cat2"]:
+        dst = outdir / f"CMS-HGG_sigfit_{ext}_{cat}.root"
+
+        if dst.exists() or dst.is_symlink():
+            dst.unlink()
+
+        if label == "2022_2023_2024":
+            input_files = [
+                packaged_file(read_config(CONFIGS["2022"]), "2022", cat),
+                packaged_file(read_config(CONFIGS["2023"]), "2023", cat),
+                packaged_file(read_config(CONFIGS["2024"]), "2024", cat),
+            ]
+
+            missing_files = [path for path in input_files if not path.exists()]
+            if missing_files:
+                raise FileNotFoundError(missing_files[0])
+
+            import_workspace_objects(dst, input_files)
+        else:
+            src = packaged_file(config, label, cat)
+            if not src.exists():
+                raise FileNotFoundError(src)
+
+            dst.symlink_to(src)
+
+    return ext, output_dir, category_labels
+
+
+def run_plotter(output_dir, ext, years, category, category_labels):
+    command = [
+        sys.executable,
+        "RunPlotter.py",
+        "--procs",
+        "all",
+        "--years",
+        years,
+        "--cats",
+        category,
+        "--ext",
+        ext,
+        "--label",
+        LABEL,
+        "--translateCats",
+        str(category_labels),
+    ]
+
+    if DO_FWHM:
+        command.append("--doFWHM")
+
+    print(" ".join(command))
+    env = os.environ.copy()
+    env["RUNPLOTTER_SIGNAL_DIR"] = str(output_dir)
+    subprocess.run(command, cwd=SIGNAL_DIR, env=env, check=True)
+
+
+def main():
+    os.environ["ANALYSIS_PATH"] = str(ROOT)
+    os.environ["PYTHONPATH"] = f"{ROOT / 'commonTools'}:{os.environ.get('PYTHONPATH', '')}"
+
+    jobs = []
+
+    for label, config_path in CONFIGS.items():
+        config = read_config(config_path)
+        ext, output_dir, category_labels = make_runplotter_inputs(label, config)
+
+        for years in PLOT_YEARS[label]:
+            for category in CATEGORIES.values():
+                jobs.append((output_dir, ext, years, category, category_labels))
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = [pool.submit(run_plotter, *job) for job in jobs]
+        for future in as_completed(futures):
+            future.result()
+
+
+if __name__ == "__main__":
+    main()

--- a/Signal/run_inclusive_splusb_model_plots.py
+++ b/Signal/run_inclusive_splusb_model_plots.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CONFIGS = {
+    "2022": ROOT / "config/2022_inclusive.yml",
+    "2023": ROOT / "config/2023_inclusive.yml",
+    "2024": ROOT / "config/2024_inclusive.yml",
+    "2022_2023_2024": ROOT / "config/2022_2023_2024_inclusive.yml",
+}
+
+GROUPS = {
+    "best": "Best resolution",
+    "medium": "Medium resolution",
+    "worst": "Worst resolution",
+    "all": "All categories",
+    "weighted": "S/(S+B) weighted categories",
+}
+
+LUMI_LABELS = {
+    "2022": "34.7 fb^{-1} (13.6 TeV)",
+    "2023": "27.6 fb^{-1} (13.6 TeV)",
+    "2024": "109.8 fb^{-1} (13.6 TeV)",
+    "2022_2023_2024": "172.1 fb^{-1} (13.6 TeV)",
+}
+
+MAX_WORKERS = 8
+
+
+def read_config(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def output_dir(config):
+    return Path(config["outputFolder"].rstrip("/"))
+
+
+def datacard_path(config, label):
+    return output_dir(config) / "Combine" / f"Datacard_{label}.root"
+
+
+def cats_for(label, group):
+    cat = {"best": "cat0", "medium": "cat1", "worst": "cat2"}[group]
+
+    if label == "2022_2023_2024":
+        return f"Y22_{cat},Y23_{cat},Y24_{cat}"
+
+    return cat
+
+
+def write_labels(path, label):
+    labels = {
+        "cat0": "Best resolution",
+        "cat1": "Medium resolution",
+        "cat2": "Worst resolution",
+        "all": label,
+    }
+
+    with open(path, "w") as f:
+        json.dump(labels, f, indent=2)
+
+
+def run_plot(datacard, workdir, year_label, group, cats):
+    group_label = GROUPS[group]
+    ext = f"_{datacard.stem.replace('Datacard_', '')}_{group}"
+    labels_path = workdir / f"labels_{group}.json"
+    write_labels(labels_path, group_label)
+
+    command = [
+        sys.executable,
+        str(ROOT / "Plots/makeSplusBModelPlot.py"),
+        "--inputWSFile",
+        str(datacard),
+        "--cats",
+        cats,
+        "--doZeroes",
+        "--translateCats",
+        str(labels_path),
+        "--lumiLabel",
+        LUMI_LABELS[year_label],
+        "--ext",
+        ext,
+    ]
+
+    if "," in cats or cats == "all":
+        command += ["--doSumCategories", "--skipIndividualCatPlots"]
+
+    if group == "weighted":
+        command.append("--doCatWeights")
+
+    print(" ".join(command))
+    subprocess.run(command, cwd=workdir, check=True)
+
+
+def main():
+    os.environ["ANALYSIS_PATH"] = str(ROOT)
+    os.environ["PYTHONPATH"] = f"{ROOT / 'commonTools'}:{os.environ.get('PYTHONPATH', '')}"
+
+    jobs = []
+
+    for label, config_path in CONFIGS.items():
+        config = read_config(config_path)
+        datacard = datacard_path(config, label)
+        workdir = output_dir(config) / "Combine" / "splusb_model_plots"
+        workdir.mkdir(parents=True, exist_ok=True)
+
+        if not datacard.exists():
+            raise FileNotFoundError(datacard)
+
+        for group in GROUPS:
+            cats = "all" if group in ["all", "weighted"] else cats_for(label, group)
+            jobs.append((datacard, workdir, label, group, cats))
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = [pool.submit(run_plot, *job) for job in jobs]
+        for future in as_completed(futures):
+            future.result()
+
+
+if __name__ == "__main__":
+    main()

--- a/commonTools/plottingTools.py
+++ b/commonTools/plottingTools.py
@@ -368,7 +368,7 @@ def makeSplusBPlot(workspace,hD,hSB,hB,hS,hDr,hBr,hSr,cat,options,dB=None,reduce
   lat0.DrawLatex(0.12,0.92,"#bf{CMS} #it{Preliminary}")
   #lat0.DrawLatex(0.12,0.92,"#bf{CMS}")
   #lat0.DrawLatex(0.6,0.92,"137 fb^{-1} (13 TeV)")
-  lat0.DrawLatex(0.6,0.92,"61.9 fb^{-1} (13.6 TeV)")
+  lat0.DrawLatex(0.6,0.92,getattr(options, "lumiLabel", "61.9 fb^{-1} (13.6 TeV)"))
   lat0.DrawLatex(0.6,0.8,"#scale[0.6]{%s}"%Translate(cat,translateCats))
   #lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H#rightarrow#gamma#gamma}")
   lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H #rightarrow #gamma#gamma, m_{H} = 125.38 GeV}")


### PR DESCRIPTION
## Summary

This PR adds two lightweight helper scripts for inclusive plotting workflows:

- `Signal/run_inclusive_mass_resolution_plots.py`
- `Signal/run_inclusive_splusb_model_plots.py`

The scripts are intentionally simple and hard-code only the useful inclusive configs:

- `config/2022_inclusive.yml`
- `config/2023_inclusive.yml`
- `config/2024_inclusive.yml`
- `config/2022_2023_2024_inclusive.yml`

## Changes

- Add a simple parallel runner for inclusive mass-resolution plots.
- Add a simple parallel runner for inclusive S+B model plots.
- Store generated plots inside each config’s configured `outputFolder`.
- Support the combined `2022_2023_2024` mass-resolution workflow by building temporary combined RunPlotter inputs from the yearly packaged signal workspaces.
- Add cleaner category labels in the mass-resolution plots.
- Add both unweighted and S/(S+B)-weighted category-combined S+B plots.
- Add configurable luminosity labels for S+B plots.
- Add a small `RUNPLOTTER_SIGNAL_DIR` override to `Signal/RunPlotter.py` so wrapper scripts can redirect plotting inputs/outputs without changing the default behavior.

