### PR TITLE
update higgs mass to run 1 + run 2 hyy combination

### DIFF
--- a/Combine/RunText2Workspace.py
+++ b/Combine/RunText2Workspace.py
@@ -11,7 +11,7 @@ def get_options():
   parser.add_option("--outputName", dest='outputName', default='Datacard', help="Name of the workspace. Can be custom.")
   parser.add_option('--mode', dest='mode', default='mu_inclusive', help="Physics Model (specified in models.py)")
   parser.add_option('--ext',dest='ext', default="", help='In case running over datacard with extension')
-  parser.add_option('--common_opts',dest='common_opts', default="-m 125 higgsMassRange=122,128", help='Common options')
+  parser.add_option('--common_opts',dest='common_opts', default="-m 125.07 higgsMassRange=122,128", help='Common options')
   parser.add_option('--batch', dest='batch', default='condor', help="Batch system [SGE,IC,condor]")
   parser.add_option('--queue', dest='queue', default='workday', help="Condor queue")
   parser.add_option('--ncpus', dest='ncpus', default=4, type='int', help="Number of cpus")

--- a/Combine/law_combine.py
+++ b/Combine/law_combine.py
@@ -538,7 +538,7 @@ class RunText2Workspace(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
             "--outputDir", temp_output_dir,
             "--outputName", workspace_name,
             "--mode", mode,
-            "--common_opts", "-m 125.38 higgsMassRange=122,128",
+            "--common_opts", "-m 125.07 higgsMassRange=122,128",
             "--batch", "local"
         ]
         if self.variable != '':
@@ -648,7 +648,7 @@ class AsimovFitCategoryFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Loca
             
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov')]
 
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombinefirstStep_{current_branch}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombinefirstStep_{current_branch}.MultiDimFit.mH125.07.root')]
         output += [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'multidimfitfirstStep_{current_branch}.root')]
         
         outputFileTargets = []
@@ -711,7 +711,7 @@ class AsimovFitCategoryFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Loca
                 "-M", "MultiDimFit",
                 datacard_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"firstStep_{current_branch}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -749,7 +749,7 @@ class AsimovFitCategoryFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Loca
                 "-M", "MultiDimFit",
                 datacard_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"firstStep_{current_branch}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -974,7 +974,7 @@ class AsimovFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
             
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov')]
         
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -1027,7 +1027,7 @@ class AsimovFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
 
         def check_pdf_idx(param):
             # Run the ROOT command
-            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.07.root")\''
             
             # Execute the command and capture the output
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
@@ -1051,7 +1051,7 @@ class AsimovFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
 
         pdfIdx = check_pdf_idx(current_cat)
 
-        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f"higgsCombinefirstStep_{current_cat}.MultiDimFit.mH125.38.root")
+        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f"higgsCombinefirstStep_{current_cat}.MultiDimFit.mH125.07.root")
 
         if self.variable == '':
             arguments = [
@@ -1060,7 +1060,7 @@ class AsimovFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "-d", firstStepPath,
                 "--snapshotName", "MultiDimFit",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"AsimovPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -1116,7 +1116,7 @@ class AsimovFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "-M", "MultiDimFit",
                 "-d", firstStepPath,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"AsimovPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -1264,7 +1264,7 @@ class AsimovFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
         # output = [os.path.join(output_dir, 'Combine', fitFolderName)]
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov')]
         
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{current_cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{current_cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -1321,7 +1321,7 @@ class AsimovFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
         
         def check_pdf_idx(param):
             # Run the ROOT command
-            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.07.root")\''
             
             # Execute the command and capture the output
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
@@ -1345,7 +1345,7 @@ class AsimovFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
         
         pdfIdx = check_pdf_idx(current_cat)        
 
-        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f"higgsCombinefirstStep_{current_cat}.MultiDimFit.mH125.38.root")
+        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f"higgsCombinefirstStep_{current_cat}.MultiDimFit.mH125.07.root")
         
         if self.variable == '':
             arguments = [
@@ -1354,7 +1354,7 @@ class AsimovFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "-d", firstStepPath,
                 "--snapshotName", "MultiDimFit",
                 "--freezeParameters", "allConstrainedNuisances,MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"AsimovPostFitScanStat_{current_cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -1411,7 +1411,7 @@ class AsimovFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "-M", "MultiDimFit",
                 "-d", firstStepPath,
                 "--freezeParameters", "allConstrainedNuisances,MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"AsimovPostFitScanStat_{current_cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -1633,14 +1633,14 @@ class CreateAsimovFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow):
                 f"{os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{cat}.root')}"
             ]
             for i in range(config["combine_fit"]["asimov_numPoints"]):
-                arguments.append(os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.38.root'))
+                arguments.append(os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.07.root'))
             if self.batch_flavor == "slurm/psi":
                 arguments = [
                     "hadd", "-f",
                     f"{os.path.join(os.environ['TARGET_PATH'], 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{cat}.root')}"
                 ]
                 for i in range(config["combine_fit"]["asimov_numPoints"]):
-                    arguments.append(os.path.join(os.environ['TARGET_PATH'], 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.38.root'))
+                    arguments.append(os.path.join(os.environ['TARGET_PATH'], 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanFit_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.07.root'))
             command = arguments
             # print(command)
             try:
@@ -1657,14 +1657,14 @@ class CreateAsimovFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow):
                 f"{os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{cat}.root')}"
             ]
             for i in range(config["combine_fit"]["asimov_numPoints"]):
-                arguments.append(os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.38.root'))
+                arguments.append(os.path.join(output_dir, 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.07.root'))
             if self.batch_flavor == "slurm/psi":
                 arguments = [
                     "hadd", "-f",
                     f"{os.path.join(os.environ['TARGET_PATH'], 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{cat}.root')}"
                 ]
                 for i in range(config["combine_fit"]["asimov_numPoints"]):
-                    arguments.append(os.path.join(os.environ['TARGET_PATH'], 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.38.root'))
+                    arguments.append(os.path.join(os.environ['TARGET_PATH'], 'Combine', fitFolderName, 'asimov', f'higgsCombineAsimovPostFitScanStat_{cat}.POINTS.{i}.{i}.MultiDimFit.mH125.07.root'))
             command = arguments
             print(command)
             try:
@@ -1797,7 +1797,7 @@ class AsimovImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
         # output = [os.path.join(output_dir, 'Combine', fitFolderName)]
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'impact')]
 
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -1854,7 +1854,7 @@ class AsimovImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
             pdf_idx_param = combineVariableDict(self.variable, self.year)['paramStrNoOne'][0]
 
         def check_pdf_idx(param):
-            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.07.root")\''
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
             pdfIdx = result.stdout.strip()
             if result.returncode != 0:
@@ -1867,7 +1867,7 @@ class AsimovImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
             return pdfIdx
 
         pdfIdx = None
-        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.38.root")
+        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.07.root")
         if os.path.exists(first_step_path):
             pdfIdx = check_pdf_idx(pdf_idx_param)
         else:
@@ -1884,7 +1884,7 @@ class AsimovImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "--doInitialFit",
                 "--robustFit", "1",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
                 "--X-rtd", "MINIMIZER_freezeDisassociatedParams",
@@ -1913,7 +1913,7 @@ class AsimovImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "--algo", "singles",
                 "--redefineSignalPOIs", f"""{",".join(combineVariableDict(self.variable, self.year)['paramStrNoOne'])}""",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", "_initialFit_Test",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -2094,7 +2094,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
         # output = [os.path.join(output_dir, 'Combine', fitFolderName)]
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'impact')]
 
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', f'higgsCombine_paramFit_Test_{current_param}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', f'higgsCombine_paramFit_Test_{current_param}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -2152,7 +2152,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             pdf_idx_param = combineVariableDict(self.variable, self.year)['paramStrNoOne'][0]
 
         def check_pdf_idx(param):
-            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.07.root")\''
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
             pdfIdx = result.stdout.strip()
             if result.returncode != 0:
@@ -2165,7 +2165,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             return pdfIdx
 
         pdfIdx = None
-        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.38.root")
+        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.07.root")
         if os.path.exists(first_step_path):
             pdfIdx = check_pdf_idx(pdf_idx_param)
         else:
@@ -2182,7 +2182,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "--algo", "impact",
                 "--redefineSignalPOIs", "r",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-P", f"{current_param}",
                 "--floatOtherPOIs", "1",
                 "--saveInactivePOI", "1",
@@ -2216,7 +2216,7 @@ class AsimovImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "--algo", "impact",
                 "--redefineSignalPOIs", f"""{",".join(combineVariableDict(self.variable, self.year)['paramStrNoOne'])}""",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-P", f"{current_param}",
                 "--floatOtherPOIs", "1",
                 "--saveInactivePOI", "1",
@@ -2408,7 +2408,7 @@ class AsimovImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
             base_param_string = ",".join(combineVariableDict(self.variable, self.year)['paramStr'])
 
         def check_pdf_idx(param):
-            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.38.root")\''
+            command = f'root -l -q \'{os.environ["ANALYSIS_PATH"]}/Combine/checkPdfIdx.C("{first_output}/higgsCombinefirstStep_{param}.MultiDimFit.mH125.07.root")\''
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
             pdfIdx = result.stdout.strip()
             if result.returncode != 0:
@@ -2421,7 +2421,7 @@ class AsimovImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
             return pdfIdx
 
         pdfIdx = None
-        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.38.root")
+        first_step_path = os.path.join(first_output, f"higgsCombinefirstStep_{pdf_idx_param}.MultiDimFit.mH125.07.root")
         if os.path.exists(first_step_path):
             pdfIdx = check_pdf_idx(pdf_idx_param)
         else:
@@ -2441,7 +2441,7 @@ class AsimovImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "-M", "Impacts",
                 "-d", datacard_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-o", "impacts/impacts.json",
                 "--named", ",".join(named_params),
             ]
@@ -2495,7 +2495,7 @@ class AsimovImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 "-M", "Impacts",
                 "-d", datacard_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-o", "impacts/impacts.json",
             ]
             # combineTool.py currently uses "all free parameters" by default (equivalent to --allPars),
@@ -2637,7 +2637,7 @@ class AsimovCovCorrHesse(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflo
             
             output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'robustHessefirstStep.root')]
             output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'multidimfitfirstStep.root')]
-            output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'higgsCombinefirstStep.MultiDimFit.mH125.38.root')]
+            output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'higgsCombinefirstStep.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -2706,7 +2706,7 @@ class AsimovCovCorrHesse(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflo
             "-M", "MultiDimFit",
             datacard_path,
             "--freezeParameters", "MH",
-            "-m", "125.38",
+            "-m", "125.07",
             "-n", "firstStep",
             "--saveWorkspace",
             "--saveFitResult",
@@ -3027,7 +3027,7 @@ class UnblindedFitSystSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             fitFolderName = f'runFits_{self.variable}'
         
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit')]
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitBestFit_{current_cat}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitBestFit_{current_cat}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -3085,7 +3085,7 @@ class UnblindedFitSystSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "-M", "MultiDimFit",
                 "-d", datacard_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitBestFit_{current_cat}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3117,7 +3117,7 @@ class UnblindedFitSystSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "-M", "MultiDimFit",
                 datacard_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitBestFit_{current_cat}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3229,7 +3229,7 @@ class UnblindedFitStatSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             
         output = []
 
-        output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitBestFitStat_{cat}.MultiDimFit.mH125.38.root')]
+        output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitBestFitStat_{cat}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -3278,7 +3278,7 @@ class UnblindedFitStatSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
             execute_command([f'mkdir -p {output_dir}/Combine/{fitFolderName}/dataFit'], shell=True)
             os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit'))
     
-        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitBestFit_{cat}.MultiDimFit.mH125.38.root")
+        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitBestFit_{cat}.MultiDimFit.mH125.07.root")
         local_first_step = os.path.join(os.getcwd(), os.path.basename(firstStepPath))
         if not os.path.exists(firstStepPath):
             raise RuntimeError(f"Required best fit snapshot not found: {firstStepPath}")
@@ -3292,7 +3292,7 @@ class UnblindedFitStatSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "-M", "MultiDimFit",
                 input_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitBestFitStat_{cat}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3326,7 +3326,7 @@ class UnblindedFitStatSingle(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWor
                 "-M", "MultiDimFit",
                 input_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitBestFitStat_{cat}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3444,7 +3444,7 @@ class UnblindedFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
             fitFolderName = f'runFits_{self.variable}'
         
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit')]
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -3495,7 +3495,7 @@ class UnblindedFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
             execute_command([f'mkdir -p {output_dir}/Combine/{fitFolderName}/dataFit'], shell=True)
             os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit'))
         
-        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitBestFit_{current_cat}.MultiDimFit.mH125.38.root")
+        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitBestFit_{current_cat}.MultiDimFit.mH125.07.root")
         n_points = int(self.nPoints)
             
         if self.variable == '':
@@ -3504,7 +3504,7 @@ class UnblindedFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "-M", "MultiDimFit",
                 "-d", firstStepPath,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3536,7 +3536,7 @@ class UnblindedFitCategorySyst(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "-M", "MultiDimFit",
                 "-d", firstStepPath,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitScanFit_{current_cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3656,7 +3656,7 @@ class UnblindedFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
             fitFolderName = f'runFits_mu_fiducial'
         else:
             fitFolderName = f'runFits_{self.variable}'
-        output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanStat_{cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.38.root')]
+        output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanStat_{cat}.POINTS.{current_point}.{current_point}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -3705,7 +3705,7 @@ class UnblindedFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
             execute_command([f'mkdir -p {output_dir}/Combine/{fitFolderName}/dataFit'], shell=True)
             os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit'))
     
-        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitBestFitStat_{cat}.MultiDimFit.mH125.38.root")
+        firstStepPath = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitBestFitStat_{cat}.MultiDimFit.mH125.07.root")
         local_first_step = os.path.join(os.getcwd(), os.path.basename(firstStepPath))
         if not os.path.exists(firstStepPath):
             raise RuntimeError(f"Required stat-only best fit snapshot not found: {firstStepPath}")
@@ -3720,7 +3720,7 @@ class UnblindedFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "-M", "MultiDimFit",
                 "-d", input_path,
                 "--freezeParameters", "allConstrainedNuisances,MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitScanStat_{cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3749,7 +3749,7 @@ class UnblindedFitCategoryStat(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "-M", "MultiDimFit",
                 "-d", input_path,
                 "--freezeParameters", "allConstrainedNuisances,MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-n", f"DataPostFitScanStat_{cat}.POINTS.{current_point}.{current_point}",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
@@ -3949,9 +3949,9 @@ class CreateUnblindedFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflo
         n_points = int(config["combine_fit"]["unblindedFit_numPoints"])
 
         def hadd_scan_outputs(kind, current_cat):
-            target = os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScan{kind}_{current_cat}.MultiDimFit.mH125.38.root')
+            target = os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScan{kind}_{current_cat}.MultiDimFit.mH125.07.root')
             sources = [
-                os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScan{kind}_{current_cat}.POINTS.{idx}.{idx}.MultiDimFit.mH125.38.root')
+                os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScan{kind}_{current_cat}.POINTS.{idx}.{idx}.MultiDimFit.mH125.07.root')
                 for idx in range(n_points)
             ]
             command = ["hadd", "-f", target] + sources
@@ -3971,18 +3971,18 @@ class CreateUnblindedFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflo
                 raise RuntimeError(f"Required scan output is missing: {path}")
 
         for cat in cats:
-            fit_scan = os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH125.38.root')
-            stat_scan = os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanStat_{cat}.MultiDimFit.mH125.38.root')
+            fit_scan = os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH125.07.root')
+            stat_scan = os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanStat_{cat}.MultiDimFit.mH125.07.root')
             ensure_scan_file(fit_scan)
             ensure_scan_file(stat_scan)
 
         for cat in cats:
             arguments = [
                 "plot1DScan.py",
-                os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH125.38.root'),
+                os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH125.07.root'),
                 "-o", f"scans/scan_{cat}_observed",
                 "--POI", f"{cat}",
-                "--others", os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanStat_{cat}.MultiDimFit.mH125.38.root')+":stat-only:2",
+                "--others", os.path.join(job_datafit_dir, f'higgsCombineDataPostFitScanStat_{cat}.MultiDimFit.mH125.07.root')+":stat-only:2",
                 "--main-label", "Observed",
                 "--translate", os.path.join(os.environ["ANALYSIS_PATH"], 'Combine', 'pois.json')
             ]
@@ -4083,7 +4083,7 @@ class UnblindedCovCorrHesse(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
 
             output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'robustHessefirstStep_data.root')]
             output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'multidimfitfirstStep_data.root')]
-            output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'higgsCombinefirstStep_data.MultiDimFit.mH125.38.root')]
+            output += [os.path.join(output_dir, 'Combine', fitFolderName, 'hesse', f'higgsCombinefirstStep_data.MultiDimFit.mH125.07.root')]
             
         outputFileTargets = []
                 
@@ -4137,7 +4137,7 @@ class UnblindedCovCorrHesse(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
             "-M", "MultiDimFit",
             datacard_path,
             "--freezeParameters", "MH",
-            "-m", "125.38",
+            "-m", "125.07",
             "-n", "firstStep_data",
             "--saveWorkspace",
             "--saveFitResult",
@@ -4448,7 +4448,7 @@ class UnblindedImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
             
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded')]
 
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -4509,7 +4509,7 @@ class UnblindedImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "--doInitialFit",
                 "--robustFit", "1",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "--cminDefaultMinimizerStrategy=0",
                 "--cminFallbackAlgo", "Minuit2,Migrad,1:10",
                 "--X-rtd", "MINIMIZER_freezeDisassociatedParams",
@@ -4535,7 +4535,7 @@ class UnblindedImpactFirstStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "--algo", "singles",
                 "--redefineSignalPOIs", f"""{",".join(combineVariableDict(self.variable, self.year)['paramStrNoOne'])}""",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "--robustFit", "1",
                 "-n", "_initialFit_Test",
                 "--cminDefaultMinimizerStrategy=0",
@@ -4685,7 +4685,7 @@ class UnblindedImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Local
         # output = [os.path.join(output_dir, 'Combine', fitFolderName)]
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded')]
 
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_paramFit_Test_{current_param}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_paramFit_Test_{current_param}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -4744,7 +4744,7 @@ class UnblindedImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Local
 
         if self.variable == '':
             
-            initial_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.38.root')
+            initial_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.07.root')
             
             f = ROOT.TFile(initial_fit)
             tree = f.Get("limit")
@@ -4769,7 +4769,7 @@ class UnblindedImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Local
                 "--algo", "impact",
                 "--redefineSignalPOIs", "r",
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-P", f"{current_param}",
                 "--setParameters", poi_bf_string,
                 "--floatOtherPOIs", "1",
@@ -4797,7 +4797,7 @@ class UnblindedImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Local
                 print("Error executing script:", e.stderr)
         else:
 
-            initial_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.38.root')
+            initial_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'impact', 'unblinded', f'higgsCombine_initialFit_Test.MultiDimFit.mH125.07.root')
 
             poi_bf = []
             
@@ -4829,7 +4829,7 @@ class UnblindedImpactSecondStep(Task, HTCondorWorkflow, SlurmWorkflow, law.Local
                 "--redefineSignalPOIs", f"""{",".join(combineVariableDict(self.variable, self.year)['paramStrNoOne'])}""",
                 "--setParameters", poi_bf_string,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-P", f"{current_param}",
                 "--floatOtherPOIs", "1",
                 "--saveInactivePOI", "1",
@@ -5022,7 +5022,7 @@ class UnblindedImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "combineTool.py",
                 "-M", "Impacts",
                 "-d", datacard_path,
-                "-m", "125.38",
+                "-m", "125.07",
                 "-o", "impacts/impacts.json"
             ]
             command = arguments
@@ -5071,7 +5071,7 @@ class UnblindedImpactThirdStep(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalW
                 "-M", "Impacts",
                 "-d", datacard_path,
                 "--freezeParameters", "MH",
-                "-m", "125.38",
+                "-m", "125.07",
                 "-o", "impacts/impacts.json",
             ]
             if (config["combine_impacts"]["exclude"] != ""):
@@ -5218,7 +5218,7 @@ class MggBestFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(la
             
         output = [os.path.join(output_dir, 'Combine', fitFolderName, 'postFit')]
         output += [os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}')]
-        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}', f'higgsCombine_bestfit_syst_obs_{cat}.MultiDimFit.mH125.38.root')]
+        output += [os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}', f'higgsCombine_bestfit_syst_obs_{cat}.MultiDimFit.mH125.07.root')]
         
         outputFileTargets = []
                 
@@ -5284,7 +5284,7 @@ class MggBestFit(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow): #(la
             "--X-rtd", "MINIMIZER_multiMin_maskConstraints",
             "--X-rtd", "MINIMIZER_multiMin_maskChannels=2",
             "-M", f"{config['combine_mggToys']['loadSnapshot']}",
-            "-m", "125.38",
+            "-m", "125.07",
             "-d", datacard_path,
             "-n", f"_bestfit_syst_obs_{cat}"
         ]
@@ -5478,7 +5478,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
                 execute_command([f'mkdir -p {output_dir}/Combine/{fitFolderName}/postFit/SplusBModels_{cat}/toys/filechecker'], shell=True)
                 os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}', 'toys'))
         
-            best_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}', f'higgsCombine_bestfit_syst_obs_{cat}.MultiDimFit.mH125.38.root')
+            best_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}', f'higgsCombine_bestfit_syst_obs_{cat}.MultiDimFit.mH125.07.root')
 
             f = ROOT.TFile(best_fit)
             w = f.Get("w")
@@ -5489,7 +5489,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
                 "combine",
                 best_fit,
                 "-M", "GenerateOnly",
-                "-m", "125.380",
+                "-m", "125.070",
                 "--saveWorkspace",
                 "--toysFrequentist",
                 "--bypassFrequentistFit",
@@ -5541,7 +5541,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
             arguments = [
                 "combine",
                 f"gen_{toy}.root",
-                "-m", "125.380",
+                "-m", "125.070",
                 "-M", f"{config['combine_mggToys']['loadSnapshot']}",
                 "-P", f"{cat}",
                 "--floatOtherPOIs=1",
@@ -5592,7 +5592,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
             arguments = [
                 "combine",
                 f"fit_{toy}.root",
-                "-m", "125.380",
+                "-m", "125.070",
                 "--snapshotName", f"{config['combine_mggToys']['loadSnapshot']}",
                 "-M", "GenerateOnly",
                 "--saveToys",
@@ -5683,7 +5683,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
                 "combine",
                 "-M", "GenerateOnly",
                 "-d", datacard_path,
-                "-m", "125.380",
+                "-m", "125.070",
                 "--saveWorkspace",
                 "--toysFrequentist",
                 "--bypassFrequentistFit",
@@ -5738,7 +5738,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
             arguments = [
                 "combine",
                 f"gen_{toy}.root",
-                "-m", "125.380",
+                "-m", "125.070",
                 "-M", f"{config['combine_mggToys']['loadSnapshot']}",
                 "-P", f"{cat}",
                 "--floatOtherPOIs=1",
@@ -5793,7 +5793,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
             arguments = [
                 "combine",
                 f"fit_{toy}.root",
-                "-m", "125.38",
+                "-m", "125.07",
                 "--snapshotName", f"{config['combine_mggToys']['loadSnapshot']}",
                 "-M", "GenerateOnly",
                 "--saveToys",
@@ -6064,7 +6064,7 @@ class MggDistribution(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow):
                 execute_command([f'mkdir -p {output_dir}/Combine/{fitFolderName}/postFit/SplusBModels_{cat}/'], shell=True)
                 os.chdir(os.path.join(output_dir, 'Combine', fitFolderName, 'postFit'))
             
-            best_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}', f'higgsCombine_bestfit_syst_obs_{cat}.MultiDimFit.mH125.38.root')
+            best_fit = os.path.join(output_dir, 'Combine', fitFolderName, 'postFit', f'SplusBModels_{cat}', f'higgsCombine_bestfit_syst_obs_{cat}.MultiDimFit.mH125.07.root')
             
             if self.variable == '':
                 # firstStep_path = os.path.join(output_dir, 'Combine', f'Datacard_{self.year}.root')
@@ -6079,7 +6079,7 @@ class MggDistribution(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow):
                     reco_cats_with_bmw = cats
 
             else:
-                # firstStep_path = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH125.38.root')
+                # firstStep_path = os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH125.07.root')
                 reco_cats_with_bmw = [element for element in combineVariableDict(self.variable, self.year)['catsStrWithBMW'] if "_".join(cat.split("_")[2:]) in element]
                 if "_" in self.year:
                     cats = []
@@ -6314,7 +6314,7 @@ class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
             output = []
         else:
             fitFolderName = f'runFits_{self.variable}'
-            output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombine.pvalue.MultiDimFit.mH125.38.root')]
+            output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombine.pvalue.MultiDimFit.mH125.07.root')]
             output += [os.path.join(output_dir, 'Combine', fitFolderName, f'pvalue.txt')]
 
         outputFileTargets = []
@@ -6363,7 +6363,7 @@ class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
             temp_output_dir = output_dir
                     
         # Define the file to check
-        pvalue_file = os.path.join(temp_output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombine.pvalue.MultiDimFit.mH125.38.root')
+        pvalue_file = os.path.join(temp_output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombine.pvalue.MultiDimFit.mH125.07.root')
         # Check if the file exists
         if not os.path.isfile(pvalue_file):
             print("The pvalue file does not exist in the current directory. Creating it...")
@@ -6371,7 +6371,7 @@ class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
             command = [
                 "combine",
                 "-M", "MultiDimFit",
-                os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitScanFit_{combineVariableDict(self.variable, self.year)['paramStrNoOne'][0]}.MultiDimFit.mH125.38.root"),
+                os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f"higgsCombineDataPostFitScanFit_{combineVariableDict(self.variable, self.year)['paramStrNoOne'][0]}.MultiDimFit.mH125.07.root"),
                 "--algo", "fixed",
                 "--X-rtd", "MINIMIZER_freezeDisassociatedParams",
                 "--X-rtd", "MINIMIZER_multiMin_hideConstants",
@@ -6381,9 +6381,9 @@ class PValueCalculation(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow
                 "--cminFallbackAlgo", "Minuit2,Simplex,0:0.1",
                 "--cminFallbackAlgo", "Minuit2,Combined,0:0.1",
                 "--freezeParameters", "MH",
-                "--fixedPointPOIs", f"{','.join(combineVariableDict(self.variable, self.year)['paramStr'])},MH=125.38",
+                "--fixedPointPOIs", f"{','.join(combineVariableDict(self.variable, self.year)['paramStr'])},MH=125.07",
                 "-n", ".pvalue",
-                "-m", "125.38",
+                "-m", "125.07",
                 "--saveWorkspace"
             ]
             try:

--- a/Combine/law_combine.py
+++ b/Combine/law_combine.py
@@ -42,6 +42,13 @@ def convert_boolean_string(string):
     else:
         return False
 
+def get_lumi_label(year):
+    if year in lumiMap:
+        lumi = lumiMap[year]
+    else:
+        lumi = sum(lumiMap[y] for y in re.split(r"[,_]", str(year)) if y in lumiMap)
+    return f"{lumi:.1f} fb^{{-1}} (13.6 TeV)"
+
 
 _PDFINDEX_CACHE = {}
 
@@ -5489,7 +5496,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
                 "combine",
                 best_fit,
                 "-M", "GenerateOnly",
-                "-m", "125.070",
+                "-m", "125.07",
                 "--saveWorkspace",
                 "--toysFrequentist",
                 "--bypassFrequentistFit",
@@ -5541,7 +5548,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
             arguments = [
                 "combine",
                 f"gen_{toy}.root",
-                "-m", "125.070",
+                "-m", "125.07",
                 "-M", f"{config['combine_mggToys']['loadSnapshot']}",
                 "-P", f"{cat}",
                 "--floatOtherPOIs=1",
@@ -5592,7 +5599,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
             arguments = [
                 "combine",
                 f"fit_{toy}.root",
-                "-m", "125.070",
+                "-m", "125.07",
                 "--snapshotName", f"{config['combine_mggToys']['loadSnapshot']}",
                 "-M", "GenerateOnly",
                 "--saveToys",
@@ -5683,7 +5690,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
                 "combine",
                 "-M", "GenerateOnly",
                 "-d", datacard_path,
-                "-m", "125.070",
+                "-m", "125.07",
                 "--saveWorkspace",
                 "--toysFrequentist",
                 "--bypassFrequentistFit",
@@ -5738,7 +5745,7 @@ class MggToyGeneration(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow)
             arguments = [
                 "combine",
                 f"gen_{toy}.root",
-                "-m", "125.070",
+                "-m", "125.07",
                 "-M", f"{config['combine_mggToys']['loadSnapshot']}",
                 "-P", f"{cat}",
                 "--floatOtherPOIs=1",
@@ -6094,6 +6101,7 @@ class MggDistribution(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow):
                 "--inputWSFile", best_fit,
                 "--loadSnapshot", f"{config['combine_mggToys']['loadSnapshot']}",
                 "--cats", f"{','.join(reco_cats_with_bmw)}",
+                "--lumiLabel", get_lumi_label(self.year),
                 "--doZeroes",
                 "--unblind",
                 "--translateCats", f"{os.path.join(os.environ['ANALYSIS_PATH'], 'Plots', 'cats.json')}",
@@ -6203,6 +6211,7 @@ class MggDistribution(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWorkflow):
                 f"{os.path.join(os.environ['ANALYSIS_PATH'], 'Plots', 'makeSplusBModelPlot.py')}",
                 "--inputWSFile", datacard_path,
                 "--cats", f"{','.join(reco_cats_with_bmw)}",
+                "--lumiLabel", get_lumi_label(self.year),
                 "--doZeroes",
                 "--blindingRegion", "125,125",
                 "--translateCats", f"{os.path.join(os.environ['ANALYSIS_PATH'], 'Plots', 'cats.json')}",

--- a/Datacard/systematics.py
+++ b/Datacard/systematics.py
@@ -111,21 +111,21 @@ theory_systematics = [
                 # For some reason, the name is saved only as `Scal`, not `Scale`, do not ask me why
                 # Comment out the nominal weight here as it does not contain any `tiers`, so it would fail in `makeDatacard.py``
                 # The scheme below is valid for v13, you need to explicitly check the nanoAOD documentation to validate your setup
-                {'name':'weight_LHEScal_0','title':'CMS_hgg_scaleWeight_0','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, 
-                {'name':'weight_LHEScal_1','title':'CMS_hgg_scaleWeight_1','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                #{'name':'weight_LHEScal_2','title':'CMS_hgg_scaleWeight_2','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, #Unphysical
-                {'name':'weight_LHEScal_3','title':'CMS_hgg_scaleWeight_3','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                # {'name':'weight_LHEScal_4','title':'CMS_hgg_scaleWeight_4','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, #nominal weight
-                {'name':'weight_LHEScal_5','title':'CMS_hgg_scaleWeight_5','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                #{'name':'weight_LHEScal_6','title':'CMS_hgg_scaleWeight_6','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, #Unphysical
-                {'name':'weight_LHEScal_7','title':'CMS_hgg_scaleWeight_7','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                {'name':'weight_LHEScal_8','title':'CMS_hgg_scaleWeight_8','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                {'name':'weight_AlphaS','title':'CMS_hgg_AlphaS','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                {'name':'weight_PS_ISR','title':'CMS_hgg_PS_ISR','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                {'name':'weight_PS_FSR','title':'CMS_hgg_PS_FSR','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                {'name':'weight_LHEScal_0','title':'CMS_HIG26007_scaleWeight_0','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, 
+                {'name':'weight_LHEScal_1','title':'CMS_HIG26007_scaleWeight_1','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                #{'name':'weight_LHEScal_2','title':'CMS_HIG26007_scaleWeight_2','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, #Unphysical
+                {'name':'weight_LHEScal_3','title':'CMS_HIG26007_scaleWeight_3','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                # {'name':'weight_LHEScal_4','title':'CMS_HIG26007_scaleWeight_4','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, #nominal weight
+                {'name':'weight_LHEScal_5','title':'CMS_HIG26007_scaleWeight_5','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                #{'name':'weight_LHEScal_6','title':'CMS_HIG26007_scaleWeight_6','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']}, #Unphysical
+                {'name':'weight_LHEScal_7','title':'CMS_HIG26007_scaleWeight_7','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                {'name':'weight_LHEScal_8','title':'CMS_HIG26007_scaleWeight_8','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                {'name':'weight_AlphaS','title':'pdf_alphas','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                {'name':'weight_PS_ISR','title':'ps_isr','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                {'name':'weight_PS_FSR','title':'ps_fsr','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
                 # Hopefully I did not forget any theory weights???
-                #{'name':'alphaSWeight_0','title':'CMS_hgg_alphaSWeight_0','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
-                #{'name':'alphaSWeight_1','title':'CMS_hgg_alphaSWeight_1','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                #{'name':'alphaSWeight_0','title':'CMS_HIG26007_alphaSWeight_0','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
+                #{'name':'alphaSWeight_1','title':'CMS_HIG26007_alphaSWeight_1','type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']},
 
                 # Theory uncertainties for constrained to SM bins
                 #{'name':'THU_qqH_Yield_qqH_cnstr','title':'STXS_constrain_THU_qqH_Yield','type':'constant','prior':'lnN','correlateAcrossYears':1,'value':'theory_uncertainties/thu_qqh_stxs_constrain.json'},
@@ -143,7 +143,7 @@ theory_systematics = [
               ]
 # PDF weight
 # For some reason, at the moment the LHEPdf weights are stored with `Pd` instead of `Pdf`, no idea why
-for i in range(1,101): theory_systematics.append( {'name':'weight_LHEPd_%g'%i, 'title':'CMS_hgg_pdfWeight_%g'%i, 'type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']} )
+for i in range(1,101): theory_systematics.append( {'name':'weight_LHEPd_%g'%i, 'title':'CMS_HIG26007_pdfWeight_%g'%i, 'type':'factory','prior':'lnN','correlateAcrossYears':1,'tiers':['shape']} )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -166,30 +166,30 @@ experimental_systematics = [
                 # The scheme should be only used if you are doing 22+23 or 22+23+24. For other combinations, see the link above
                 # If you use 22+23, you can comment out lumi_3 (otherwise you will have empty dashes in the datacard, which is also not a big problem)
                 # Note: If you want to have a result for multiple years with combinedCards, you should prepare the individual datacards with the following lines
-                {'name':'lumi_1','title':'lumi_1','type':'constant','prior':'lnN','correlateAcrossYears':1,'value':{"2022preEE": "1.0138", "2022postEE": "1.0138", "2022": "1.0138", "2023preBPix": "1.0017", "2023postBPix": "1.0017", "2023": "1.0017", "2024": "1.0020"}},
-                {'name':'lumi_2','title':'lumi_2','type':'constant','prior':'lnN','correlateAcrossYears':1,'value':{"2023preBPix": "1.0127", "2023postBPix": "1.0127", "2023": "1.0127", "2024": "1.0068"}},
-                {'name':'lumi_3','title':'lumi_3','type':'constant','prior':'lnN','correlateAcrossYears':1,'value':{"2024": "1.0144"}},
+                {'name':'lumi_1','title':'lumi_13p6TeV_222324','type':'constant','prior':'lnN','correlateAcrossYears':1,'value':{"2022preEE": "1.0138", "2022postEE": "1.0138", "2022": "1.0138", "2023preBPix": "1.0017", "2023postBPix": "1.0017", "2023": "1.0017", "2024": "1.0020"}},
+                {'name':'lumi_2','title':'lumi_13p6TeV_2324','type':'constant','prior':'lnN','correlateAcrossYears':1,'value':{"2023preBPix": "1.0127", "2023postBPix": "1.0127", "2023": "1.0127", "2024": "1.0068"}},
+                {'name':'lumi_3','title':'lumi_13p6TeV_2024','type':'constant','prior':'lnN','correlateAcrossYears':1,'value':{"2024": "1.0144"}},
                 ### Other experimental nuisances
-                {'name':'weight_Pileup','title':'CMS_hgg_PileupWeight','type':'factory','prior':'lnN','correlateAcrossYears':1},
-                {'name':'weight_TriggerSF','title':'CMS_hgg_TriggerWeight','type':'factory','prior':'lnN','correlateAcrossYears':1},
-                {'name':'weight_ElectronVetoSF','title':'CMS_hgg_ElectronVetoSF','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                {'name':'weight_PreselSF','title':'CMS_hgg_PreselSF','type':'factory','prior':'lnN','correlateAcrossYears':1},
-                {'name':'weight_SF_photon_ID','title':'CMS_hgg_phoIdMva','type':'factory','prior':'lnN','correlateAcrossYears':1},
-                #{'name':'LooseMvaSF','title':'CMS_hgg_LooseMvaSF','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'PreselSF','title':'CMS_hgg_PreselSF','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'electronVetoSF','title':'CMS_hgg_electronVetoSF','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'TriggerWeight','title':'CMS_hgg_TriggerWeight','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'MuonIDWeight','title':'CMS_hgg_MuonID','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'MuonIsoWeight','title':'CMS_hgg_MuonIso','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'ElectronIDWeight','title':'CMS_hgg_ElectronID','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'ElectronRecoWeight','title':'CMS_hgg_ElectronReco','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'JetBTagCutWeight','title':'CMS_hgg_BTagCut','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'JetBTagReshapeWeight','title':'CMS_hgg_BTagReshape','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'prefireWeight','title':'CMS_hgg_prefire','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                {'name':'energyErrShift','title':'CMS_hgg_SigmaEOverEShift','type':'factory','prior':'lnN','correlateAcrossYears':1},
-                #{'name':'SigmaEOverEShift','title':'CMS_hgg_SigmaEOverEShift','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'MvaShift','title':'CMS_hgg_phoIdMva','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'PUJIDShift','title':'CMS_hgg_PUJIDShift','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                {'name':'weight_Pileup','title':'CMS_pileup','type':'factory','prior':'lnN','correlateAcrossYears':1},
+                {'name':'weight_TriggerSF','title':'CMS_HIG26007_TriggerSF','type':'factory','prior':'lnN','correlateAcrossYears':1},
+                {'name':'weight_ElectronVetoSF','title':'CMS_eff_g_CSEV_13p6TeV','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                {'name':'weight_PreselSF','title':'CMS_HIG26007_PreselSF','type':'factory','prior':'lnN','correlateAcrossYears':1},
+                {'name':'weight_SF_photon_ID','title':'CMS_HIG26007_phoIdMva','type':'factory','prior':'lnN','correlateAcrossYears':1},
+                #{'name':'LooseMvaSF','title':'CMS_HIG26007_LooseMvaSF','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'PreselSF','title':'CMS_HIG26007_PreselSF','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'electronVetoSF','title':'CMS_HIG26007_electronVetoSF','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'TriggerWeight','title':'CMS_HIG26007_TriggerWeight','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'MuonIDWeight','title':'CMS_HIG26007_MuonID','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'MuonIsoWeight','title':'CMS_HIG26007_MuonIso','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'ElectronIDWeight','title':'CMS_HIG26007_ElectronID','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'ElectronRecoWeight','title':'CMS_HIG26007_ElectronReco','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'JetBTagCutWeight','title':'CMS_HIG26007_BTagCut','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'JetBTagReshapeWeight','title':'CMS_HIG26007_BTagReshape','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'prefireWeight','title':'CMS_HIG26007_prefire','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                {'name':'energyErrShift','title':'CMS_HIG26007_SigmaEOverEShift','type':'factory','prior':'lnN','correlateAcrossYears':1},
+                #{'name':'SigmaEOverEShift','title':'CMS_HIG26007_SigmaEOverEShift','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'MvaShift','title':'CMS_HIG26007_phoIdMva','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'PUJIDShift','title':'CMS_HIG26007_PUJIDShift','type':'factory','prior':'lnN','correlateAcrossYears':0},
                 # New partial correlation scheme for JECs (do not use in addition to nominal 'JEC')
                 #{'name':'JECAbsolute','title':'CMS_scale_j_Absolute','type':'factory','prior':'lnN','correlateAcrossYears':1},
                 #{'name':'JECFlavorQCD','title':'CMS_scale_j_FlavorQCD','type':'factory','prior':'lnN','correlateAcrossYears':1},
@@ -205,12 +205,12 @@ experimental_systematics = [
                
                 {'name':'JecSystTotal','title':'CMS_scale_j','type':'factory','prior':'lnN','correlateAcrossYears':0},
                 {'name':'JerSyst','title':'CMS_res_j','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'metJecUncertainty','title':'CMS_hgg_MET_scale_j','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'metJerUncertainty','title':'CMS_hgg_MET_res_j','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'metPhoUncertainty','title':'CMS_hgg_MET_PhotonScale','type':'factory','prior':'lnN','correlateAcrossYears':0},
-                #{'name':'metUncUncertainty','title':'CMS_hgg_MET_Unclustered','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'metJecUncertainty','title':'CMS_HIG26007_MET_scale_j','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'metJerUncertainty','title':'CMS_HIG26007_MET_res_j','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'metPhoUncertainty','title':'CMS_HIG26007_MET_PhotonScale','type':'factory','prior':'lnN','correlateAcrossYears':0},
+                #{'name':'metUncUncertainty','title':'CMS_HIG26007_MET_Unclustered','type':'factory','prior':'lnN','correlateAcrossYears':0},
                 # HEM issue systematic
-                #{'name':'JetHEM','title':'CMS_hgg_JetHEM','type':'factory','prior':'lnN','correlateAcrossYears':0}
+                #{'name':'JetHEM','title':'CMS_HIG26007_JetHEM','type':'factory','prior':'lnN','correlateAcrossYears':0}
               ]
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -219,13 +219,13 @@ experimental_systematics = [
 # mode = (other,scalesGlobal,scales,scalesCorr,smears): match the definition in the signal models
 
 signal_shape_systematics = [
-                {'name':'deltafracright','title':'deltafracright','type':'signal_shape','mode':'other','mean':'0.0','sigma':'0.02'},
+                {'name':'deltafracright','title':'CMS_HIG26007_deltafracright','type':'signal_shape','mode':'other','mean':'0.0','sigma':'0.02'},
                 #{'name':'scale','title':'scale','type':'signal_shape','mode':'scales','mean':'0.0','sigma':'1.0'},
-                {'name':'ScaleEBZee','title':'ScaleEBZee','type':'signal_shape','mode':'scales','mean':'0.0','sigma':'1.0'},
-                {'name':'ScaleEEZee','title':'ScaleEEZee','type':'signal_shape','mode':'scales','mean':'0.0','sigma':'1.0'},
-                {'name':'ScaleEBZmmg','title':'ScaleEBZmmg','type':'signal_shape','mode':'scalesCorr','mean':'0.0','sigma':'1.0'},
-                {'name':'ScaleEEZmmg','title':'ScaleEEZmmg','type':'signal_shape','mode':'scalesCorr','mean':'0.0','sigma':'1.0'},
-                {'name':'Smearing','title':'Smearing','type':'signal_shape','mode':'smears','mean':'0.0','sigma':'1.0'},
+                {'name':'ScaleEBZee','title':'CMS_HIG26007_ScaleEBZee','type':'signal_shape','mode':'scales','mean':'0.0','sigma':'1.0'},
+                {'name':'ScaleEEZee','title':'CMS_HIG26007_ScaleEEZee','type':'signal_shape','mode':'scales','mean':'0.0','sigma':'1.0'},
+                {'name':'ScaleEBZmmg','title':'CMS_HIG26007_ScaleEBZmmg','type':'signal_shape','mode':'scalesCorr','mean':'0.0','sigma':'1.0'},
+                {'name':'ScaleEEZmmg','title':'CMS_HIG26007_ScaleEEZmmg','type':'signal_shape','mode':'scalesCorr','mean':'0.0','sigma':'1.0'},
+                {'name':'Smearing','title':'CMS_HIG26007_Smearing','type':'signal_shape','mode':'smears','mean':'0.0','sigma':'1.0'},
                 #{'name':'Material','title':'Material','type':'signal_shape','mode':'scalesCorr','mean':'0.0','sigma':'1.0'},
                 #{'name':'FNUF','title':'FNUF','type':'signal_shape','mode':'scalesCorr','mean':'0.0','sigma':'1.0'},
                 #{'name':'NonLinearity','title':'NonLinearity','type':'signal_shape','mode':'scalesGlobal','mean':'0.0','sigma':'0.005'},

--- a/Plots/Spectra/law_spectra.py
+++ b/Plots/Spectra/law_spectra.py
@@ -28,6 +28,8 @@ from Combine.law_combine import *
 from framework import Task
 from framework import HTCondorWorkflow, SlurmWorkflow
 
+HIGGS_MASS = "125.07"
+
 # Function to safely create a directory
 def safe_mkdir(path):
     try:
@@ -254,8 +256,8 @@ class CreateDiffSpectra(law.Task):#(law.Task): #(Task, HTCondorWorkflow, law.Loc
                 # oneSigmaDict[f'{cat}'] = {}
                 
                 if convert_boolean_string(self.is_unblinded):
-                    main_scan_syst = BuildScan(cat, [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH125.38.root')], yvals, y_cut)
-                    main_scan_stat = BuildScan(cat, [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanStat_{cat}.MultiDimFit.mH125.38.root')], yvals, y_cut)
+                    main_scan_syst = BuildScan(cat, [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanFit_{cat}.MultiDimFit.mH{HIGGS_MASS}.root')], yvals, y_cut)
+                    main_scan_stat = BuildScan(cat, [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombineDataPostFitScanStat_{cat}.MultiDimFit.mH{HIGGS_MASS}.root')], yvals, y_cut)
                     
                     pvalue_path = os.path.join(output_dir, 'Combine', fitFolderName, 'pvalue.txt')
                     

--- a/Plots/makeCorrMatrix.py
+++ b/Plots/makeCorrMatrix.py
@@ -8,6 +8,8 @@ import json
 import os
 import re
 
+HIGGS_MASS = "125.07"
+
 def get_options():
   parser = OptionParser()
   parser.add_option('--inputJson', dest='inputJson', default='inputs.json', help="Input json file to define fits")
@@ -110,6 +112,13 @@ for mode,pois in modes.items():
 
   if mode.count('stage1p2'): canv = setCanvasCorr(stage='1p2')
   elif mode.count('mu_reco'): canv = setCanvasCorr(stage='1p2')
+  elif mode.count("PTH"):
+    canv = ROOT.TCanvas("can", "can", 1200, 1100)
+    canv.GetPad(0).SetTopMargin(0.11)
+    canv.GetPad(0).SetRightMargin(0.16)
+    canv.GetPad(0).SetLeftMargin(0.24)
+    canv.GetPad(0).SetBottomMargin(0.27)
+    canv.GetPad(0).SetTicks(1, 1)
   else:
     if opt.doCov:
       canv = setCanvas()
@@ -162,10 +171,10 @@ for mode,pois in modes.items():
     theHist.GetXaxis().LabelsOption("v")
     if opt.doCov:
       if mode.count("PTH"):
-        label_size = 0.05
+        label_size = 0.035
         theHist.GetXaxis().SetLabelSize(label_size)
         theHist.GetYaxis().SetLabelSize(label_size)
-        theHist.SetMarkerSize(2)
+        theHist.SetMarkerSize(0.95)
       else:
         label_size = 0.06
         theHist.GetXaxis().SetLabelSize(label_size)
@@ -173,7 +182,7 @@ for mode,pois in modes.items():
         theHist.SetMarkerSize(2)
     else:
       if mode.count("PTH"):
-        label_size = 0.05
+        label_size = 0.035
       elif mode.count("rapidity"):
         label_size = 0.06
       elif mode.count("NJ"):
@@ -184,7 +193,10 @@ for mode,pois in modes.items():
         label_size = 0.03
       theHist.GetXaxis().SetLabelSize(label_size)
       theHist.GetYaxis().SetLabelSize(label_size)
-      theHist.SetMarkerSize(1.5)
+      if mode.count("PTH"):
+        theHist.SetMarkerSize(0.85)
+      else:
+        theHist.SetMarkerSize(1.5)
   else:
     theHist.GetYaxis().SetLabelOffset(0.007)  
     theHist.SetMarkerSize(1.5)
@@ -192,27 +204,33 @@ for mode,pois in modes.items():
   latex = ROOT.TLatex()
   latex.SetNDC()
   latex.SetTextFont(42)
-  latex.SetTextAlign(32)
-  latex.SetTextSize(0.045)
-  x_modifier_cms = 0.57 # 0.62
-  if opt.doCov:
-    x_modifier_cms = 0.53 # 0.53
+  latex.SetTextAlign(12)
+  if mode.count("PTH"):
+    top_text_size = 0.03
+    info_text_size = 0.032
+  else:
+    top_text_size = 0.045
+    info_text_size = 0.04
+  latex.SetTextSize(top_text_size)
+  cms_x = canv.GetLeftMargin() + 0.005
+  top_y = 1.00-canv.GetTopMargin()+0.025
   if opt.doObserved:
     if opt.noPreliminary:
-      latex.DrawLatex(1.00-canv.GetRightMargin()-x_modifier_cms,1.0-canv.GetTopMargin()+0.025,'#bf{CMS}')
+      latex.DrawLatex(cms_x, top_y, '#bf{CMS}')
     else:
-      latex.DrawLatex(1.00-canv.GetRightMargin()-x_modifier_cms,1.00-canv.GetTopMargin()+0.025,'#bf{CMS} #it{Preliminary}')
+      latex.DrawLatex(cms_x, top_y, '#bf{CMS} #it{Preliminary}')
   else:
     if opt.noPreliminary:
-      latex.DrawLatex(1.00-canv.GetRightMargin()-x_modifier_cms,1.00-canv.GetTopMargin()+0.025,'#bf{CMS} #it{Simulation}')
+      latex.DrawLatex(cms_x, top_y, '#bf{CMS} #it{Simulation}')
     else:
-      latex.DrawLatex(1.00-canv.GetRightMargin()-x_modifier_cms,1.00-canv.GetTopMargin()+0.025,'#bf{CMS} #it{Simulation Preliminary}')
-  latex.SetTextSize(0.04)
-  latex.DrawLatex(1.00-canv.GetRightMargin()-0.,1.00-canv.GetTopMargin()+0.025,'%0.1f fb^{-1} (13.6 TeV)'%lumiMap[f"{opt.year}"])
-  latex.SetTextSize(0.04)
+      latex.DrawLatex(cms_x, top_y, '#bf{CMS} #it{Simulation Preliminary}')
+  latex.SetTextSize(top_text_size)
+  latex.SetTextAlign(32)
+  latex.DrawLatex(1.00-canv.GetRightMargin(), top_y, '%0.1f fb^{-1} (13.6 TeV)'%lumiMap[f"{opt.year}"])
+  latex.SetTextSize(info_text_size)
   latex.DrawLatex(1.00-canv.GetRightMargin()-0.02,1.00-canv.GetTopMargin()-0.04,f'{translate[opt.mode]}')
   latex.DrawLatex(1.00-canv.GetRightMargin()-0.02,1.00-canv.GetTopMargin()-0.10,'H #rightarrow #gamma#gamma')
-  latex.DrawLatex(1.00-canv.GetRightMargin()-0.02,1.00-canv.GetTopMargin()-0.15,'#font[52]{m}_{H} = 125.38 GeV')
+  latex.DrawLatex(1.00-canv.GetRightMargin()-0.02,1.00-canv.GetTopMargin()-0.15,'#font[52]{m}_{H} = %s GeV' % HIGGS_MASS)
   
   for binx in range(1, theHist.GetNbinsX() + 1):
     for biny in range(1, theHist.GetNbinsY() + 1):

--- a/Plots/plottingTools.py
+++ b/Plots/plottingTools.py
@@ -238,10 +238,10 @@ def makeSplusBPlot(workspace,hD,hSB,hB,hS,hDr,hBr,hSr,cat,options,dB=None,reduce
   lat0.DrawLatex(0.12,0.92,"#bf{CMS} #it{Preliminary}")
   #lat0.DrawLatex(0.12,0.92,"#bf{CMS}")
   #lat0.DrawLatex(0.6,0.92,"137 fb^{-1} (13 TeV)")
-  lat0.DrawLatex(0.565,0.92,"61.9 fb^{-1} (13.6 TeV)")
+  lat0.DrawLatex(0.565,0.92,options.lumiLabel)
   lat0.DrawLatex(0.6,0.8,"#scale[0.6]{%s}"%Translate(cat,translateCats))
   #lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H#rightarrow#gamma#gamma}")
-  lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H #rightarrow #gamma#gamma, m_{H} = 125.38 GeV}")
+  lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H #rightarrow #gamma#gamma, m_{H} = 125.07 GeV}")
   if "PseudoToy" in options.inputWSFile:
     lat0.DrawLatex(0.15,0.76,"#scale[0.75]{Pseudo data}")
   if(options.loadSnapshot is not None):

--- a/commonTools/plottingTools.py
+++ b/commonTools/plottingTools.py
@@ -368,10 +368,10 @@ def makeSplusBPlot(workspace,hD,hSB,hB,hS,hDr,hBr,hSr,cat,options,dB=None,reduce
   lat0.DrawLatex(0.12,0.92,"#bf{CMS} #it{Preliminary}")
   #lat0.DrawLatex(0.12,0.92,"#bf{CMS}")
   #lat0.DrawLatex(0.6,0.92,"137 fb^{-1} (13 TeV)")
-  lat0.DrawLatex(0.6,0.92,"61.9 fb^{-1} (13.6 TeV)")
+  lat0.DrawLatex(0.6,0.92,getattr(options, "lumiLabel", "172.1 fb^{-1} (13.6 TeV)"))
   lat0.DrawLatex(0.6,0.8,"#scale[0.6]{%s}"%Translate(cat,translateCats))
   #lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H#rightarrow#gamma#gamma}")
-  lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H #rightarrow #gamma#gamma, m_{H} = 125.38 GeV}")
+  lat0.DrawLatex(0.15,0.83,"#scale[0.75]{H #rightarrow #gamma#gamma, m_{H} = 125.07 GeV}")
   if "PseudoToy" in options.inputWSFile:
     lat0.DrawLatex(0.15,0.76,"#scale[0.75]{Pseudo data}")
   if(options.loadSnapshot is not None):

--- a/law/analysis.py
+++ b/law/analysis.py
@@ -29,6 +29,8 @@ def convert_boolean_string(string):
     else:
         return False
 
+HIGGS_MASS = "125.07"
+
 class FinalFits(law.WrapperTask):
     years = law.Parameter(default="2022,2023,2024")
     variable = law.Parameter(default="")
@@ -217,7 +219,7 @@ class FinalFits(law.WrapperTask):
                     f"--outputDir {output_dir} "
                     f"--outputName Datacard_{combined_label} "
                     "--mode mu_fiducial "
-                    "--common_opts \"-m 125.38 higgsMassRange=122,128\" "
+                    f"--common_opts \"-m {HIGGS_MASS} higgsMassRange=122,128\" "
                     "--batch local"
                 )
             else:
@@ -230,7 +232,7 @@ class FinalFits(law.WrapperTask):
                     f"--outputDir {output_dir} "
                     f"--outputName Datacard_{self.variable}_{combined_label} "
                     f"--mode {self.variable} "
-                    "--common_opts \"-m 125.38 higgsMassRange=122,128\" "
+                    f"--common_opts \"-m {HIGGS_MASS} higgsMassRange=122,128\" "
                     "--batch local "
                     f"--ext {self.variable}"
                 )
@@ -643,7 +645,7 @@ class FinalFitsYear(law.Task):
                 print("P-value calculation is not supported for inclusive fits.")
                 exit(1)
             else:
-                output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombine.pvalue.MultiDimFit.mH125.38.root')]
+                output = [os.path.join(output_dir, 'Combine', fitFolderName, 'dataFit', f'higgsCombine.pvalue.MultiDimFit.mH{HIGGS_MASS}.root')]
                 output += [os.path.join(output_dir, 'Combine', fitFolderName, f'pvalue.txt')]
 
             for _, current_output_path in enumerate(output):


### PR DESCRIPTION
## Summary
Updates the Higgs mass value used throughout the framework from `125.38 GeV` to `125.07 GeV`, the combined Run 1 + Run 2 H→γγ mass measurement, and aligns systematic uncertainty naming with the analysis conventions (HIG-26-007).

## Changes
- **Higgs mass update (`125.38` → `125.07` GeV)**: propagated to all `combine` calls and output filenames across `Combine/law_combine.py` (`RunText2Workspace`, `AsimovFitCategoryFirstStep`, `AsimovFitCategorySyst`, `AsimovFitCategoryStat`, `CreateAsimovFit`, `MggToyGeneration`, `MggDistribution`), as well as the default `--common_opts` in `Combine/RunText2Workspace.py` and the spectra plotting code in `Plots/Spectra/law_spectra.py` (introduced a `HIGGS_MASS` constant for consistency).
- **Systematic naming convention update** (`Datacard/systematics.py`): renamed nuisance titles from the generic `CMS_hgg_*` scheme to the `CMS_HIG26007_*` convention (theory weights, scale factors, signal-shape systematics, etc.), renamed luminosity nuisances to `lumi_13p6TeV_*` to reflect the data-taking eras combined (`222324`, `2324`, `2024`), and switched `weight_AlphaS`/`weight_PS_ISR`/`weight_PS_FSR`/`weight_Pileup` to the shared `pdf_alphas`/`ps_isr`/`ps_fsr`/`CMS_pileup` names.
- **Plot/luminosity labels**: added a `get_lumi_label()` helper in `law_combine.py` that builds the correct `"<lumi> fb⁻¹ (13.6 TeV)"` label per year/era combination, and wired it into the `MggDistribution` (`makeSplusBModelPlot`, mGG distribution) plotting calls; adjusted `Plots/makeCorrMatrix.py` canvas/label/marker sizing for the `PTH` correlation matrices to improve readability with the finer binning.
- Minor consistency fixes: dropped the redundant `-m 125.070` → `-m 125.07` formatting in toy generation, and an EOF newline cleanup in `RunText2Workspace.py`.

## Notes
This branch also carries forward the accumulated differential-binning work (underflow bins, replacement-map updates, new 2022/2023/2024 `NJ`/`PTH`/`rapidity`/`PTJ0` configs, Asimov correlation-matrix fixes) that `Zmmg_SaS_222324` does not yet have, since it branches off PR #81.
