### PR TITLE
Fix correlation scheme for Zmmg SaS new naming

### DIFF
--- a/Datacard/datacardTools/writeToDatacard.py
+++ b/Datacard/datacardTools/writeToDatacard.py
@@ -88,7 +88,9 @@ def writeSystematic(f,d,s,options,stxsMergeScheme=None,scaleCorrScheme=None):
         stitle += "_%s"%outputNuisanceExtMap[s['mode']]
     # Hard-coded split for Zmmg scale nuisances:
     # correlate 2022 and 2023 with each other, but keep 2024 separate.
-    if s['title'] in ['ScaleEBZmmg', 'ScaleEEZmmg']:
+    # Match both the old bare titles and the new CMS_HIG26007-prefixed titles.
+    zmmgScaleNames = ['ScaleEBZmmg', 'ScaleEEZmmg']
+    if s.get('name') in zmmgScaleNames or any(s['title'].endswith(name) for name in zmmgScaleNames):
       years = options.years.split(",")
       if any(isZmmgScale2022Or2023Label(year) for year in years):
         lsyst = "%-70s  param    %-6s %-6s"%(f"{stitle}_2022_2023",s['mean'],s['sigma'])


### PR DESCRIPTION
## Summary

This MR updates the Run 3 differential configuration and datacard handling for the Zmmg final-fit workflow.

Main changes:

- Add/update differential configs for the new/updated observables, including YJ0, MassJ0J1, PTJ1, CosThetaStarCS, and PTHvsNJ.
- Update nuisance naming in `systematics.py` to follow the `CMS_HIG26007_*` / Run 3 naming convention.
- Keep the intended Zmmg scale correlation scheme after the nuisance renaming:
  - Zmmg scale nuisances are correlated between 2022 and 2023.
  - 2024 Zmmg scale nuisances remain separate.
- Keep smearing nuisances split per year/era.
- Add protection for very long `--saveSpecifiedIndex` arguments in combine calls, avoiding broken/zombie ROOT outputs when the pdfindex payload becomes too large.
- Add/update plotting and fiducial cross-section helper files needed for the new differential observables.

## Notes

The nuisance renaming changes the datacard nuisance names but keeps the intended correlation flags. Newly produced datacards should therefore be internally consistent, while older datacards using the previous `CMS_hgg_*` naming should not be mixed without care.

The `--saveSpecifiedIndex` guard only affects cases where the argument becomes too long; otherwise the previous behavior is unchanged.