### PR TITLE
Fix Zmmg signal shape nuisance naming

### DIFF
--- a/Datacard/datacardTools/writeToDatacard.py
+++ b/Datacard/datacardTools/writeToDatacard.py
@@ -82,13 +82,15 @@ def writeSystematic(f,d,s,options,stxsMergeScheme=None,scaleCorrScheme=None):
 
   # For signal shape systematics add simple line
   if s['type'] == 'signal_shape':
-    stitle = "%s_%s"%(outputWSNuisanceTitle__,s['title'])
+    stitle = s['title']
     if s['mode'] != 'other':
       if outputNuisanceExtMap[s['mode']] != '':
         stitle += "_%s"%outputNuisanceExtMap[s['mode']]
     # Hard-coded split for Zmmg scale nuisances:
     # correlate 2022 and 2023 with each other, but keep 2024 separate.
-    if s['title'] in ['ScaleEBZmmg', 'ScaleEEZmmg']:
+    # Match both the old bare titles and the new CMS_HIG26007-prefixed titles.
+    zmmgScaleNames = ['ScaleEBZmmg', 'ScaleEEZmmg']
+    if s.get('name') in zmmgScaleNames or any(s['title'].endswith(name) for name in zmmgScaleNames):
       years = options.years.split(",")
       if any(isZmmgScale2022Or2023Label(year) for year in years):
         lsyst = "%-70s  param    %-6s %-6s"%(f"{stitle}_2022_2023",s['mean'],s['sigma'])
@@ -144,7 +146,7 @@ def writeSystematic(f,d,s,options,stxsMergeScheme=None,scaleCorrScheme=None):
             match = re.search(r'\d{4}', y)
             if match:
               year_tokens.add(match.group(0))
-          use_run3_shared_name = re.fullmatch(r"lumi_\d+", s['title']) is not None
+          use_run3_shared_name = re.fullmatch(r"lumi_\d+", s['name']) is not None
           if (len(year_tokens) == 1) and (not use_run3_shared_name):
             stitle = "%s_%s"%(stitle, next(iter(year_tokens)))
         lsyst = '%-50s  %-10s    '%(stitle,s['prior'])

--- a/Signal/tools/finalModel.py
+++ b/Signal/tools/finalModel.py
@@ -80,6 +80,11 @@ def initialiseXSBR():
   if('ggZH' in productionModes)&('ZH' in productionModes): xsbr['qqZH'] = xsbr['ZH']-xsbr['ggZH']
   return xsbr
 
+def getSignalShapeNuisanceParamName(nuisanceName):
+  if (nuisanceName == 'deltafracright') or nuisanceName.startswith('Scale') or nuisanceName.startswith('Smearing'):
+    return "CMS_HIG26007_%s"%nuisanceName
+  return "%s_%s"%(outputWSNuisanceTitle__,nuisanceName)
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
 class FinalModel:
   # Constructor
@@ -180,9 +185,10 @@ class FinalModel:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Function for making nuisance param w/ info to add to Nuisance dict
   def makeNuisance(self,nuisanceName,nuisanceMeanConst,nuisanceSigmaConst,nuisanceRateConst,nuisanceType,nuisanceOpts=[]):
+    nuisanceParamName = getSignalShapeNuisanceParamName(nuisanceName)
     self.NuisanceMap[nuisanceType][nuisanceName] = {
       'name':nuisanceName,
-      'param':ROOT.RooRealVar("%s_%s"%(outputWSNuisanceTitle__,nuisanceName),"%s_%s"%(outputWSNuisanceTitle__,nuisanceName),0.,-5.,5.),
+      'param':ROOT.RooRealVar(nuisanceParamName,nuisanceParamName,0.,-5.,5.),
       'meanConst':ROOT.RooConstVar("const_%s_mean_%s"%(self.name,nuisanceName),"const_%s_mean_%s"%(self.name,nuisanceName),nuisanceMeanConst),
       'sigmaConst':ROOT.RooConstVar("const_%s_sigma_%s"%(self.name,nuisanceName),"const_%s_sigma_%s"%(self.name,nuisanceName),nuisanceSigmaConst),
       'rateConst':ROOT.RooConstVar("const_%s_rate_%s"%(self.name,nuisanceName),"const_%s_rate_%s"%(self.name,nuisanceName),nuisanceRateConst),


### PR DESCRIPTION
This MR fixes the naming of the photon energy scale/smearing signal-shape nuisances so that the names used in the datacards match the RooFit nuisance variables created inside the signal workspaces.

Previously, the datacards could contain CMS_HIG26007-prefixed nuisance names while the signal workspaces still created the corresponding RooRealVars with the internal CMS_hgg_nuisance_* prefix. In that case Combine treated the datacard nuisances as disconnected parameters, which caused the scale/smearing impacts to fail or appear flat.

The signal model construction now creates the relevant signal-shape nuisance parameters using the public CMS_HIG26007_* names for:
- deltafracright
- ScaleEBZee / ScaleEEZee
- ScaleEBZmmg / ScaleEEZmmg
- Smearing

The datacard writer uses the systematic title directly for signal-shape nuisances, preserving the same CMS_HIG26007_* naming convention in the datacards. The existing year-dependent naming and the 2022/2023 vs 2024 split for the Zmmg scale nuisances are kept unchanged.

With this change, newly generated signal workspaces and datacards use matching nuisance names, so the corresponding parameters are correctly connected in Combine.