### PR TITLE
Add new MassJ0J1 binning on HIG-19-016 setup

### DIFF
--- a/Combine/models.py
+++ b/Combine/models.py
@@ -29,7 +29,7 @@ def _build_pth_model():
   for _bin in _PTH_BINS:
     for _proc in _PTH_PROCS:
       segments.append(
-        f'--PO "map=.*/{_proc}_PTH_{_bin}.*:r_PTH_{_bin}[1,-1,3]"'
+        f'--PO "map=.*/{_proc}_PTH_{_bin}_in.*:r_PTH_{_bin}[1,-1,3]"'
       )
   return " ".join(segments)
 
@@ -54,7 +54,34 @@ def _build_massj0j1_model():
   for _bin in _MASSJ0J1_BINS:
     for _proc in _MASSJ0J1_PROCS:
       segments.append(
-        f'--PO "map=.*/{_proc}_MassJ0J1_{_bin}.*:r_MassJ0J1_{_bin}[1,-8,8]"'
+        f'--PO "map=.*/{_proc}_MassJ0J1_{_bin}_in.*:r_MassJ0J1_{_bin}[1,-8,8]"'
+      )
+  return " ".join(segments)
+
+
+_RAPIDITY_BINS = [
+  "0p0_0p15",
+  "0p15_0p3",
+  "0p3_0p45",
+  "0p45_0p6",
+  "0p6_0p75",
+  "0p75_0p9",
+  "0p9_1p2",
+  "1p2_1p6",
+  "1p6_2p0",
+  "2p0_2p5",
+]
+_RAPIDITY_PROCS = ["ggh", "tth", "vh", "vbf"]
+
+
+def _build_rapidity_model():
+  segments = [
+    "-P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel",
+  ]
+  for _bin in _RAPIDITY_BINS:
+    for _proc in _RAPIDITY_PROCS:
+      segments.append(
+        f'--PO "map=.*/{_proc}_YH_{_bin}_in.*:r_YH_{_bin}[1,-3,3]"'
       )
   return " ".join(segments)
 
@@ -319,47 +346,7 @@ models = {
 
   "MassJ0J1": _build_massj0j1_model(),
 
-  "rapidity":"-P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel \
---PO \"map=.*/ggh_YH_0p0_0p15.*:r_YH_0p0_0p15[1,-3,3]\" \
---PO \"map=.*/tth_YH_0p0_0p15.*:r_YH_0p0_0p15[1,-3,3]\" \
---PO \"map=.*/vh_YH_0p0_0p15.*:r_YH_0p0_0p15[1,-3,3]\" \
---PO \"map=.*/vbf_YH_0p0_0p15.*:r_YH_0p0_0p15[1,-3,3]\" \
---PO \"map=.*/ggh_YH_0p15_0p3.*:r_YH_0p15_0p3[1,-3,3]\" \
---PO \"map=.*/tth_YH_0p15_0p3.*:r_YH_0p15_0p3[1,-3,3]\" \
---PO \"map=.*/vh_YH_0p15_0p3.*:r_YH_0p15_0p3[1,-3,3]\" \
---PO \"map=.*/vbf_YH_0p15_0p3.*:r_YH_0p15_0p3[1,-3,3]\" \
---PO \"map=.*/ggh_YH_0p3_0p45.*:r_YH_0p3_0p45[1,-3,3]\" \
---PO \"map=.*/tth_YH_0p3_0p45.*:r_YH_0p3_0p45[1,-3,3]\" \
---PO \"map=.*/vh_YH_0p3_0p45.*:r_YH_0p3_0p45[1,-3,3]\" \
---PO \"map=.*/vbf_YH_0p3_0p45.*:r_YH_0p3_0p45[1,-3,3]\" \
---PO \"map=.*/ggh_YH_0p45_0p6.*:r_YH_0p45_0p6[1,-3,3]\" \
---PO \"map=.*/tth_YH_0p45_0p6.*:r_YH_0p45_0p6[1,-3,3]\" \
---PO \"map=.*/vh_YH_0p45_0p6.*:r_YH_0p45_0p6[1,-3,3]\" \
---PO \"map=.*/vbf_YH_0p45_0p6.*:r_YH_0p45_0p6[1,-3,3]\" \
---PO \"map=.*/ggh_YH_0p6_0p75.*:r_YH_0p6_0p75[1,-3,3]\" \
---PO \"map=.*/tth_YH_0p6_0p75.*:r_YH_0p6_0p75[1,-3,3]\" \
---PO \"map=.*/vh_YH_0p6_0p75.*:r_YH_0p6_0p75[1,-3,3]\" \
---PO \"map=.*/vbf_YH_0p6_0p75.*:r_YH_0p6_0p75[1,-3,3]\" \
---PO \"map=.*/ggh_YH_0p75_0p9.*:r_YH_0p75_0p9[1,-3,3]\" \
---PO \"map=.*/tth_YH_0p75_0p9.*:r_YH_0p75_0p9[1,-3,3]\" \
---PO \"map=.*/vh_YH_0p75_0p9.*:r_YH_0p75_0p9[1,-3,3]\" \
---PO \"map=.*/vbf_YH_0p75_0p9.*:r_YH_0p75_0p9[1,-3,3]\" \
---PO \"map=.*/ggh_YH_0p9_1p2.*:r_YH_0p9_1p2[1,-3,3]\" \
---PO \"map=.*/tth_YH_0p9_1p2.*:r_YH_0p9_1p2[1,-3,3]\" \
---PO \"map=.*/vh_YH_0p9_1p2.*:r_YH_0p9_1p2[1,-3,3]\" \
---PO \"map=.*/vbf_YH_0p9_1p2.*:r_YH_0p9_1p2[1,-3,3]\" \
---PO \"map=.*/ggh_YH_1p2_1p6.*:r_YH_1p2_1p6[1,-3,3]\" \
---PO \"map=.*/tth_YH_1p2_1p6.*:r_YH_1p2_1p6[1,-3,3]\" \
---PO \"map=.*/vh_YH_1p2_1p6.*:r_YH_1p2_1p6[1,-3,3]\" \
---PO \"map=.*/vbf_YH_1p2_1p6.*:r_YH_1p2_1p6[1,-3,3]\" \
---PO \"map=.*/ggh_YH_1p6_2p0.*:r_YH_1p6_2p0[1,-3,3]\" \
---PO \"map=.*/tth_YH_1p6_2p0.*:r_YH_1p6_2p0[1,-3,3]\" \
---PO \"map=.*/vh_YH_1p6_2p0.*:r_YH_1p6_2p0[1,-3,3]\" \
---PO \"map=.*/vbf_YH_1p6_2p0.*:r_YH_1p6_2p0[1,-3,3]\" \
---PO \"map=.*/ggh_YH_2p0_2p5.*:r_YH_2p0_2p5[1,-3,3]\" \
---PO \"map=.*/tth_YH_2p0_2p5.*:r_YH_2p0_2p5[1,-3,3]\" \
---PO \"map=.*/vh_YH_2p0_2p5.*:r_YH_2p0_2p5[1,-3,3]\" \
---PO \"map=.*/vbf_YH_2p0_2p5.*:r_YH_2p0_2p5[1,-3,3]\"",
+  "rapidity": _build_rapidity_model(),
 
   "Njets2p5_5bin":"-P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel \
 --PO \"map=.*/ggh_NJ_0p0_1p0.*:r_NJ_0p0_1p0[1,0,3]\" \

--- a/Combine/models.py
+++ b/Combine/models.py
@@ -34,6 +34,31 @@ def _build_pth_model():
   return " ".join(segments)
 
 
+_MASSJ0J1_BINS = [
+  "m10000p0_0p0",
+  "0p0_75p0",
+  "75p0_120p0",
+  "120p0_180p0",
+  "180p0_300p0",
+  "300p0_500p0",
+  "500p0_1000p0",
+  "1000p0_10000p0",
+]
+_MASSJ0J1_PROCS = ["ggh", "tth", "vh", "vbf"]
+
+
+def _build_massj0j1_model():
+  segments = [
+    "-P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel",
+  ]
+  for _bin in _MASSJ0J1_BINS:
+    for _proc in _MASSJ0J1_PROCS:
+      segments.append(
+        f'--PO "map=.*/{_proc}_MassJ0J1_{_bin}.*:r_MassJ0J1_{_bin}[1,-8,8]"'
+      )
+  return " ".join(segments)
+
+
 models = {
   "mu_inclusive":"",
 
@@ -291,6 +316,8 @@ models = {
 
 
   "PTH": _build_pth_model(),
+
+  "MassJ0J1": _build_massj0j1_model(),
 
   "rapidity":"-P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel \
 --PO \"map=.*/ggh_YH_0p0_0p15.*:r_YH_0p0_0p15[1,-3,3]\" \

--- a/Signal/tools/replacementMap.py
+++ b/Signal/tools/replacementMap.py
@@ -5,7 +5,7 @@ from collections import OrderedDict as od
 # in commonTools.commonObjects (HIG-19-016 style binning).  Import with a
 # fallback so this file can still be used standalone.
 try:
-    from commonTools.commonObjects import PTH_BINS
+    from commonTools.commonObjects import MASSJ0J1_BINS, PTH_BINS
 except ImportError:
     PTH_BINS = [
         "0p0_5p0",
@@ -27,6 +27,16 @@ except ImportError:
         "250p0_350p0",
         "350p0_450p0",
         "450p0_10000p0",
+    ]
+    MASSJ0J1_BINS = [
+        "m10000p0_0p0",
+        "0p0_75p0",
+        "75p0_120p0",
+        "120p0_180p0",
+        "180p0_300p0",
+        "300p0_500p0",
+        "500p0_1000p0",
+        "1000p0_10000p0",
     ]
 
 try:
@@ -435,6 +445,24 @@ for bin_name in [
     for cat in ['cat0', 'cat1', 'cat2']:
         reco_key = f"RECO_PTJ0_{bin_name}_{cat}"
         globalReplacementMap["Run3FidXSAnalysisPTJ0"]["catRVMap"][reco_key] = reco_key
+
+
+# Differential invariant mass of the two leading jets
+_MassJ0J1_RECO_CATS = ['cat0', 'cat1', 'cat2', 'catMerged']
+_MassJ0J1_WV_BIN = "180p0_300p0"
+
+globalReplacementMap["Run3FidXSAnalysisMassJ0J1"] = od()
+globalReplacementMap["Run3FidXSAnalysisMassJ0J1"]['procWV'] = f"ggh_MassJ0J1_{_MassJ0J1_WV_BIN}_in"
+globalReplacementMap["Run3FidXSAnalysisMassJ0J1"]['catWV'] = f"RECO_MassJ0J1_{_MassJ0J1_WV_BIN}_cat2"
+
+globalReplacementMap["Run3FidXSAnalysisMassJ0J1"]['procRVMap'] = od()
+globalReplacementMap["Run3FidXSAnalysisMassJ0J1"]['catRVMap'] = od()
+for bin_name in MASSJ0J1_BINS:
+    for cat in _MassJ0J1_RECO_CATS:
+        reco_key = f"RECO_MassJ0J1_{bin_name}_{cat}"
+        globalReplacementMap["Run3FidXSAnalysisMassJ0J1"]["procRVMap"][reco_key] = f"ggh_MassJ0J1_{bin_name}_in"
+        globalReplacementMap["Run3FidXSAnalysisMassJ0J1"]["catRVMap"][reco_key] = reco_key
+
 
 # Differential YJ0 (Rapidity of the leading jet)
 globalReplacementMap["Run3FidXSAnalysisYJ0"] = od()

--- a/Trees2WS/law_trees2ws.py
+++ b/Trees2WS/law_trees2ws.py
@@ -281,7 +281,10 @@ class Trees2WSSingleProcess(Task, HTCondorWorkflow, SlurmWorkflow, law.LocalWork
                 aset = make_argset(ws,varNames)
 
                 # Convert tree to RooDataset and add to workspace
+                oldStorageType = ROOT.RooAbsData.getDefaultStorageType()
+                ROOT.RooAbsData.setDefaultStorageType(ROOT.RooAbsData.Tree)
                 d = ROOT.RooDataSet(dName,dName,aset,'weight')
+                ROOT.RooAbsData.setDefaultStorageType(oldStorageType)
                 
                 # Loop over events in dataframe and add entry
                 for row in df[mask][varNames].to_numpy():

--- a/commonTools/XSBRMap.py
+++ b/commonTools/XSBRMap.py
@@ -197,6 +197,21 @@ for _mode, _factor in [
     globalXSBRMap['Run3FidXSAnalysis'][f"{_mode}_PTH_0p0_10000p0_out"] = {'mode':'constant','factor':_factor}
 
 
+for _mode, _factor in [
+    ("ggh", 51.96),
+    ("vbf", 4.067),
+    ("vh", 2.3781),
+    ("tth", 0.5638),
+    ("bbh", 0.49),
+]:
+    for _bin in MASSJ0J1_BINS:
+        key = f"{_mode}_MassJ0J1_{_bin}_in"
+        globalXSBRMap['Run3FidXSAnalysis'][key] = {'mode':'constant','factor':_factor}
+    for _out_bin in ["m10000p0_10000p0", "0p0_10000p0"]:
+        key = f"{_mode}_MassJ0J1_{_out_bin}_out"
+        globalXSBRMap['Run3FidXSAnalysis'][key] = {'mode':'constant','factor':_factor}
+
+
 RAPIDITY_BINS = [
     "0p0_0p15",
     "0p15_0p3",

--- a/commonTools/XSBRMap.py
+++ b/commonTools/XSBRMap.py
@@ -184,6 +184,17 @@ globalXSBRMap['Run3FidXSAnalysis']['bbh_out'] = {'mode':'constant','factor':0.49
 
 
 
+def _add_differential_out_xsbr(mode, factor, variable):
+    """Add normalization entries for every declared out-of-fiducial bin."""
+    for _, process_name in differentialProcTable_[variable]:
+        if process_name.endswith("_out"):
+            key = f"{mode}_{process_name}"
+            globalXSBRMap['Run3FidXSAnalysis'][key] = {
+                'mode': 'constant',
+                'factor': factor,
+            }
+
+
 for _mode, _factor in [
     ("ggh", 51.96),
     ("vbf", 4.067),
@@ -194,7 +205,7 @@ for _mode, _factor in [
     for _bin in PTH_BINS:
         key = f"{_mode}_PTH_{_bin}_in"
         globalXSBRMap['Run3FidXSAnalysis'][key] = {'mode':'constant','factor':_factor}
-    globalXSBRMap['Run3FidXSAnalysis'][f"{_mode}_PTH_0p0_10000p0_out"] = {'mode':'constant','factor':_factor}
+    _add_differential_out_xsbr(_mode, _factor, "PTH")
 
 
 for _mode, _factor in [
@@ -207,9 +218,7 @@ for _mode, _factor in [
     for _bin in MASSJ0J1_BINS:
         key = f"{_mode}_MassJ0J1_{_bin}_in"
         globalXSBRMap['Run3FidXSAnalysis'][key] = {'mode':'constant','factor':_factor}
-    for _out_bin in ["m10000p0_10000p0", "0p0_10000p0"]:
-        key = f"{_mode}_MassJ0J1_{_out_bin}_out"
-        globalXSBRMap['Run3FidXSAnalysis'][key] = {'mode':'constant','factor':_factor}
+    _add_differential_out_xsbr(_mode, _factor, "MassJ0J1")
 
 
 RAPIDITY_BINS = [
@@ -243,7 +252,7 @@ for _mode, _factor in [
     for _bin in RAPIDITY_BINS:
         key = f"{_mode}_YH_{_bin}_in"
         globalXSBRMap['Run3FidXSAnalysis'][key] = {'mode':'constant','factor':_factor}
-    globalXSBRMap['Run3FidXSAnalysis'][f"{_mode}_YH_0p0_2p5_out"] = {'mode':'constant','factor':_factor}
+    _add_differential_out_xsbr(_mode, _factor, "rapidity")
 
 
 for _mode, _factor in [

--- a/commonTools/commonObjects.py
+++ b/commonTools/commonObjects.py
@@ -165,7 +165,8 @@ jetVariables = [
     "PTJ0",
     "YJ0",
     "AbsPhiHJ0",
-    "AbsYHJ0"
+    "AbsYHJ0",
+    "MassJ0J1"
 ]
 
 PTH_BINS = [
@@ -213,6 +214,17 @@ PTJ0_BINS = [
     "120p0_150p0",
     "150p0_200p0",
     "200p0_10000p0",
+]
+
+MASSJ0J1_BINS = [
+    "m10000p0_0p0",
+    "0p0_75p0",
+    "75p0_120p0",
+    "120p0_180p0",
+    "180p0_300p0",
+    "300p0_500p0",
+    "500p0_1000p0",
+    "1000p0_10000p0",
 ]
 
 differentialProcTable_ = {
@@ -297,6 +309,17 @@ differentialProcTable_ = {
         (73, "AbsYHJ0_1p9_100p0_in"),
         (74, "AbsYHJ0_NJ0_in"),
         (75, "AbsYHJ0_0p0_100p0_out")
+    ],
+    "MassJ0J1": [
+        (70, "MassJ0J1_m10000p0_0p0_in"),
+        (71, "MassJ0J1_0p0_75p0_in"),
+        (72, "MassJ0J1_75p0_120p0_in"),
+        (73, "MassJ0J1_120p0_180p0_in"),
+        (74, "MassJ0J1_180p0_300p0_in"),
+        (75, "MassJ0J1_300p0_500p0_in"),
+        (76, "MassJ0J1_500p0_1000p0_in"),
+        (77, "MassJ0J1_1000p0_10000p0_in"),
+        (78, "MassJ0J1_m10000p0_10000p0_out")
     ]
 }
 
@@ -309,37 +332,43 @@ combineVariableDict = {
         "rapidity": CreateVariableParameters(gen_variable="YH", reco_variable="rapidity", bins=RAPIDITY_BINS, year="2022", BMW=BMW),
         "NJ": CreateVariableParameters(gen_variable="NJ", reco_variable="NJ", bins=["0p0_1p0", "1p0_2p0", "2p0_3p0", "3p0_4p0", "4p0_100p0"], year="2022", BMW=BMW),
         "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2022", BMW=BMW),
+        "MassJ0J1": CreateVariableParameters(gen_variable="MassJ0J1", reco_variable="MassJ0J1", bins=MASSJ0J1_BINS, year="2022", BMW=BMW),
         #"PTHvsDPhiJ0J1": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=["0p0_30p0", "30p0_75p0", "75p0_120p0", "120p0_200p0", "200p0_10000p0"], year="2022", BMW=BMW)
     },
     "2023":{
         "PTH": CreateVariableParameters(gen_variable="PTH", reco_variable="PTH", bins=PTH_BINS, year="2023", BMW=BMW),
         "rapidity": CreateVariableParameters(gen_variable="YH", reco_variable="rapidity", bins=RAPIDITY_BINS, year="2023", BMW=BMW),
         "NJ": CreateVariableParameters(gen_variable="NJ", reco_variable="NJ", bins=["0p0_1p0", "1p0_2p0", "2p0_3p0", "3p0_4p0", "4p0_100p0"], year="2023", BMW=BMW),
-        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2023", BMW=BMW)
+        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2023", BMW=BMW),
+        "MassJ0J1": CreateVariableParameters(gen_variable="MassJ0J1", reco_variable="MassJ0J1", bins=MASSJ0J1_BINS, year="2023", BMW=BMW)
     },
     "2223":{
         "PTH": CreateVariableParameters(gen_variable="PTH", reco_variable="PTH", bins=PTH_BINS, year="2223", BMW=BMW),
         "rapidity": CreateVariableParameters(gen_variable="YH", reco_variable="rapidity", bins=RAPIDITY_BINS, year="2223", BMW=BMW),
         "NJ": CreateVariableParameters(gen_variable="NJ", reco_variable="NJ", bins=["0p0_1p0", "1p0_2p0", "2p0_3p0", "3p0_4p0", "4p0_100p0"], year="2223", BMW=BMW),
-        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2223", BMW=BMW)
+        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2223", BMW=BMW),
+        "MassJ0J1": CreateVariableParameters(gen_variable="MassJ0J1", reco_variable="MassJ0J1", bins=MASSJ0J1_BINS, year="2223", BMW=BMW)
     },
     "2024":{
         "PTH": CreateVariableParameters(gen_variable="PTH", reco_variable="PTH", bins=PTH_BINS, year="2024", BMW=BMW),
         "rapidity": CreateVariableParameters(gen_variable="YH", reco_variable="rapidity", bins=RAPIDITY_BINS, year="2024", BMW=BMW),
         "NJ": CreateVariableParameters(gen_variable="NJ", reco_variable="NJ", bins=["0p0_1p0", "1p0_2p0", "2p0_3p0", "3p0_4p0", "4p0_100p0"], year="2024", BMW=BMW),
-        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2024", BMW=BMW)
+        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2024", BMW=BMW),
+        "MassJ0J1": CreateVariableParameters(gen_variable="MassJ0J1", reco_variable="MassJ0J1", bins=MASSJ0J1_BINS, year="2024", BMW=BMW)
     },
     "2022_2023":{
         "PTH": CreateVariableParameters(gen_variable="PTH", reco_variable="PTH", bins=PTH_BINS, year="2022_2023", BMW=BMW),
         "rapidity": CreateVariableParameters(gen_variable="YH", reco_variable="rapidity", bins=RAPIDITY_BINS, year="2022_2023", BMW=BMW),
         "NJ": CreateVariableParameters(gen_variable="NJ", reco_variable="NJ", bins=["0p0_1p0", "1p0_2p0", "2p0_3p0", "3p0_4p0", "4p0_100p0"], year="2022_2023", BMW=BMW),
-        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2022_2023", BMW=BMW)
+        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2022_2023", BMW=BMW),
+        "MassJ0J1": CreateVariableParameters(gen_variable="MassJ0J1", reco_variable="MassJ0J1", bins=MASSJ0J1_BINS, year="2022_2023", BMW=BMW)
     },
     "2022_2023_2024":{
         "PTH": CreateVariableParameters(gen_variable="PTH", reco_variable="PTH", bins=PTH_BINS, year="2022_2023_2024", BMW=BMW),
         "rapidity": CreateVariableParameters(gen_variable="YH", reco_variable="rapidity", bins=RAPIDITY_BINS, year="2022_2023_2024", BMW=BMW),
         "NJ": CreateVariableParameters(gen_variable="NJ", reco_variable="NJ", bins=["0p0_1p0", "1p0_2p0", "2p0_3p0", "3p0_4p0", "4p0_100p0"], year="2022_2023_2024", BMW=BMW),
-        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2022_2023_2024", BMW=BMW)
+        "PTJ0": CreateVariableParameters(gen_variable="PTJ0", reco_variable="PTJ0", bins=PTJ0_BINS, year="2022_2023_2024", BMW=BMW),
+        "MassJ0J1": CreateVariableParameters(gen_variable="MassJ0J1", reco_variable="MassJ0J1", bins=MASSJ0J1_BINS, year="2022_2023_2024", BMW=BMW)
     },
 }
 

--- a/config/2022_2023_2024_MassJ0J1.yml
+++ b/config/2022_2023_2024_MassJ0J1.yml
@@ -1,0 +1,338 @@
+# Config file: options for signal fitting
+
+outputFolder: '/net/data_cms3a-1/daumann/PhD/Final_fits_repo/CMSSW_14_1_0_pre4/src/flashggFinalFit_hig19016_MassJ0J1/output_2022_2023_2024_MassJ0J1_new_binning/'
+
+inputFiles:
+  # Trees2WS
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2024/data/allData_2024.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2024/signal/'
+
+backgroundScriptCfg:
+  # Setup
+  cats: 'auto' # auto: automatically inferred from input ws
+  catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
+  ext: 'Run3FidXSAnalysis_MassJ0J1' # extension to add to output directory
+  # year: '2223' # Use combined when merging all years in category (for plots)
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+trees2wsCfg:
+  inputTreeDir: 'DiphotonTree' # Name of RooDirectory storing input tree
+
+  apply_mass_cut: False # Apply cut on CMS_hgg_mass
+  mass_cut_range: '100,180' # CMS_hgg_mass cut range
+  doSTXSSplitting: False # Split output WS per STXS bin
+  doDiffSplitting: True # Split output WS per differential bin
+  doInOutSplitting: False # Split output WS into in/out fiducial based on some variable in the input trees (to be improved).
+  doSystematics: True # Add systematics datasets to output WS
+
+  # Variables to be added to dataframe: use wildcard * for common strings
+  mainVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "weight_central"
+    - "dZ"
+    - "*Up"
+    - "*Down"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  dataVars:
+    - "CMS_hgg_mass"
+    - "weight" # Vars to be added for data
+
+  stxsVar: ''
+  diffVar: 'diffVariable_GenMassJ0J1'
+  notagVars: [] # Vars to add to NOTAG RooDataset
+
+  systematicsVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  theoryWeightContainers:
+    weight_LHEPdf: 101
+    weight_LHEScale: 9
+
+  # List of systematics: use string YEAR for year-dependent systematics
+  systematics:
+    - "ScaleEBZmmg"
+    - "ScaleEEZmmg"
+    - "ScaleEBZee"
+    - "ScaleEEZee"
+    - "Smearing"
+    - "energyErrShift"
+    - "JerSyst"
+    - "JecSystTotal"
+
+  cats: 'auto'
+
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_preEE:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2223preEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223preEE' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '50'
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.2'
+  beamspotWidthMC: '3.732'
+
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_postEE:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2223postEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223postEE' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '50'
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.5'
+  beamspotWidthMC: '3.732'
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_preBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2223preBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223preBPix' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '50'
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.703'
+  beamspotWidthMC: '3.597'
+
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2223_postBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2223postBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2223postBPix' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '50'
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.737'
+  beamspotWidthMC: '3.597'
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2024:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2024' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2024' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '25'
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.583'
+  beamspotWidthMC: '3.601'
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+packaged_2022_2023_2024:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  mergeYears: True # Merges the eras
+  ext: ''
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+datacard_yields:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  procs: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis' # Extension for saving
+  # inputWSDirMap: '2223preBPix,2223postBPix'
+  sigModelWSDir: './Models_MassJ0J1/signal' # Input signal model WS directory
+  bkgModelWSDir: './Models_MassJ0J1/background' # Input background model WS directory
+  bkgModelExt: 'multipdf' # Extension used when saving background model
+  doSystematics: True # Include systematics calculations and add to datacard
+  mergeYears: True # Merge category across years
+  skipZeroes: True # Skip signal processes with 0 sum of weights
+  ignore_warnings: True # Skip errors for missing systematics. Instead output warning message
+  mass: '125' # Input workspace mass
+  skipBkg: False # Only add signal processes to datacard
+  bkgScaler: 1. # Add overall scale factor for background
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+datacard:
+  # For pruning processes
+  prune: True # Prune proc x cat which make up less than pruneThreshold (default 0.1%) of given total category
+  pruneThreshold: 0.001 # Threshold with which to prune proc x cat as fraction of total category yield (default=0.1%)
+  doTrueYield: True # For pruning: use true number of expected events for proc x cat i.e. Product(XS,BR,eff*acc,lumi). If false then will use nominal_yield (i.e. sumEntries)
+  analysis: 'Run3FidXSAnalysis' # Analysis extension: required for doTrueYield (see ./tools/XSBR.py for example)
+
+  # For yield/systematics:
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance
+  doSystematics: True # Include systematics calculations and add to datacard
+  doMCStatUncertainty: True # Add uncertainty for MC stats
+  doSTXSMerging: False # Calculate additional migrations uncertainties for merged STXS bins (for 'mnorm' tier in systematics)
+  doSTXSScaleCorrelationScheme: False # Partially de-correlate scale uncertainties for different phase space regions
+
+  # For output:
+  saveDataFrame: False # Save final dataframe as pkl file
+  output: 'Datacard_MassJ0J1_2022_2023_2024' # Datacard name
+
+datacard_clean:
+  factor: 10000 # Factor beyond which uncertainty is considered incorrect and is removed
+  removeDoubleSided: False # Remove any nuisances which are listed as antisymmetric but both values point the same way
+  removeNonDiagonal: False # Remove any nuisances which are affect processes unimportant in that category
+  symmetrizeNuisance: 'CMS_hgg_SigmaEOverEShift,CMS_hgg_scale_0_shape,CMS_hgg_scale_1_shape,CMS_hgg_scale_3_shape' # Symmetrizes asymmetric nuisance. Enter in the format nuisance1,nuisance2,nuisance3,etc.
+  verbose: False # Spit out all the cleaning being done
+
+combine_fit:
+  asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
+  unblindedFit_numPoints: 100
+  setParameterRange: "r=-1,3"
+  rMin: 0
+  rMax: 2
+  cminApproxPreFitTolerance: 0.01
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_impacts:
+  exclude: "" # Nuisances that should be excluded from the impact computation
+  cminApproxPreFitTolerance: 0.01
+  setParameters: 1.000
+  stepSize: 0.05
+  setCrossingTolerance: 0.00005
+  not_show_POI: True
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_hesse:
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_mggToys:
+  nToys: 1000 # Number of toys = nToys * 10
+  loadSnapshot: 'MultiDimFit'
+  doBands: True
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+spectra:
+  no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
+  ggh_xs: "fidXS_MassJ0J1_ggH"
+  vbf_xs: "fidXS_MassJ0J1_VBFH"
+  vh_xs: "fidXS_MassJ0J1_VH"
+  tth_xs: "fidXS_MassJ0J1_ttH"
+  xh_xs: "fidXS_MassJ0J1_xH"
+  ggh_powheg_xs: "fidXS_MassJ0J1_ggH_powheg"
+  ggh_no_nnlops_xs: "fidXS_MassJ0J1_ggH_genWeight"
+  underflow_bin_normalized: True # Underflow bin normalized with binwidth
+  underflow_bin_width: 130
+  overflow_bin_width: 500
+  show_underflow_bin: True
+  last_bin_center: 1250
+  first_bin_center: -65
+  plot_log: 1
+  variable: "m_{jj}"
+  y_unit: "(fb/GeV)"
+  x_unit: "(GeV)"
+  x_lim: [-130, 1500]
+  y_lim: [0.0001, 2.5]
+  y_lim_top: 1000
+  overflow: 1500

--- a/config/2022_MassJ0J1.yml
+++ b/config/2022_MassJ0J1.yml
@@ -1,0 +1,251 @@
+# Config file: options for signal fitting
+
+outputFolder: '/net/data_cms3a-1/daumann/PhD/Final_fits_repo/CMSSW_14_1_0_pre4/src/flashggFinalFit_hig19016_MassJ0J1/output_2022_MassJ0J1_new_binning/'
+
+inputFiles:
+  # Trees2WS
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2022/data/allData_2022.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2022/signal/'
+
+backgroundScriptCfg:
+  # Setup
+  cats: 'auto' # auto: automatically inferred from input ws
+  catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
+  ext: 'Run3FidXSAnalysis_MassJ0J1' # extension to add to output directory
+  # year: '2022' # Use combined when merging all years in category (for plots)
+  execution: 'htcondor'
+  batchPartition: "standard" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+trees2wsCfg:
+  inputTreeDir: 'DiphotonTree' # Name of RooDirectory storing input tree
+
+  apply_mass_cut: False # Apply cut on CMS_hgg_mass
+  mass_cut_range: '100,180' # CMS_hgg_mass cut range
+  doSTXSSplitting: False # Split output WS per STXS bin
+  doDiffSplitting: True # Split output WS per differential bin
+  doInOutSplitting: False # Split output WS into in/out fiducial based on some variable in the input trees (to be improved).
+  doSystematics: True # Add systematics datasets to output WS
+
+  # Variables to be added to dataframe: use wildcard * for common strings
+  mainVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "weight_central"
+    - "dZ"
+    - "*Up"
+    - "*Down"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  dataVars:
+    - "CMS_hgg_mass"
+    - "weight" # Vars to be added for data
+
+  stxsVar: ''
+  diffVar: 'diffVariable_GenMassJ0J1'
+  notagVars: [] # Vars to add to NOTAG RooDataset
+
+  systematicsVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  theoryWeightContainers:
+    weight_LHEPdf: 101
+    weight_LHEScale: 9
+
+  # List of systematics: use string YEAR for year-dependent systematics
+  systematics:
+    - "ScaleEBZmmg"
+    - "ScaleEEZmmg"
+    - "ScaleEBZee"
+    - "ScaleEEZee"
+    - "Smearing"
+    - "energyErrShift"
+    - "JerSyst"
+    - "JecSystTotal"
+
+  cats: 'auto'
+
+  execution: 'htcondor'
+  batchPartition: "standard" # Slurm partition to use for job submission
+  batchMemory: 18000 # Slurm memory to use for job submission
+  batchMaxRuntime: "05:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2022_preEE:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2022preEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2022preEE' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '10'
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.2'
+  beamspotWidthMC: '3.732'
+
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 18000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2022_postEE:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2022postEE' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2022postEE' # Use 'combined' if merging all years: not recommended
+  replacementThreshold: '10'
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.5'
+  beamspotWidthMC: '3.732'
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+packaged_2022:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  mergeYears: True # Merges the eras
+  ext: ''
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+
+datacard_yields:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  procs: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis' # Extension for saving
+  # inputWSDirMap: '2022preEE,2022postEE'
+  sigModelWSDir: './Models_MassJ0J1/signal' # Input signal model WS directory
+  bkgModelWSDir: './Models_MassJ0J1/background' # Input background model WS directory
+  bkgModelExt: 'multipdf' # Extension used when saving background model
+  doSystematics: True # Include systematics calculations and add to datacard
+  mergeYears: True # Merge category across years
+  skipZeroes: True # Skip signal processes with 0 sum of weights
+  ignore_warnings: True # Skip errors for missing systematics. Instead output warning message
+  mass: '125' # Input workspace mass
+  skipBkg: False # Only add signal processes to datacard
+  bkgScaler: 1. # Add overall scale factor for background
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+datacard:
+  # For pruning processes
+  prune: True # Prune proc x cat which make up less than pruneThreshold (default 0.1%) of given total category
+  pruneThreshold: 0.001 # Threshold with which to prune proc x cat as fraction of total category yield (default=0.1%)
+  doTrueYield: True # For pruning: use true number of expected events for proc x cat i.e. Product(XS,BR,eff*acc,lumi). If false then will use nominal_yield (i.e. sumEntries)
+  analysis: 'Run3FidXSAnalysis' # To specify XS*BR mapping (defined in ./commonTools/XSBRMap.py)
+
+  # For yield/systematics:
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance
+  doSystematics: True # Include systematics calculations and add to datacard
+  doMCStatUncertainty: True # Add uncertainty for MC stats
+  doSTXSMerging: False # Calculate additional migrations uncertainties for merged STXS bins (for 'mnorm' tier in systematics)
+  doSTXSScaleCorrelationScheme: False # Partially de-correlate scale uncertainties for different phase space regions
+
+  # For output:
+  saveDataFrame: False # Save final dataframe as pkl file
+  output: 'Datacard_MassJ0J1_2022' # Datacard name
+
+datacard_clean:
+  factor: 10000 # Factor beyond which uncertainty is considered incorrect and is removed
+  removeDoubleSided: False # Remove any nuisances which are listed as antisymmetric but both values point the same way
+  removeNonDiagonal: False # Remove any nuisances which are affect processes unimportant in that category
+  symmetrizeNuisance: 'CMS_hgg_SigmaEOverEShift,CMS_hgg_scale_0_shape,CMS_hgg_scale_1_shape,CMS_hgg_scale_3_shape' # Symmetrizes asymmetric nuisance. Enter in the format nuisance1,nuisance2,nuisance3,etc.
+  verbose: False # Spit out all the cleaning being done
+
+combine_fit:
+  asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
+  unblindedFit_numPoints: 100
+  setParameterRange: "r=-1,3"
+  cminApproxPreFitTolerance: 0.01
+  rMin: 0
+  rMax: 2
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_impacts:
+  exclude: "" # Nuisances that should be excluded from the impact computation
+  cminApproxPreFitTolerance: 0.01
+  setParameters: 1.000
+  stepSize: 0.05
+  setCrossingTolerance: 0.00005
+  not_show_POI: True
+  execution: 'htcondor'
+  batchPartition: "standard" # Slurm partition to use for job submission
+  batchMemory: 8000 # Slurm memory to use for job submission
+  batchMaxRuntime: "08:00:00" # Slurm max runtime to use
+
+combine_hesse:
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_mggToys:
+  nToys: 1000 # Number of toys = nToys * 10
+  loadSnapshot: 'MultiDimFit'
+  doBands: True
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+spectra:
+  no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
+  ggh_xs: "fidXS_MassJ0J1_ggH"
+  vbf_xs: "fidXS_MassJ0J1_VBFH"
+  vh_xs: "fidXS_MassJ0J1_VH"
+  tth_xs: "fidXS_MassJ0J1_ttH"
+  xh_xs: "fidXS_MassJ0J1_xH"
+  ggh_powheg_xs: "fidXS_MassJ0J1_ggH_powheg"
+  ggh_no_nnlops_xs: "fidXS_MassJ0J1_ggH_genWeight"
+  underflow_bin_normalized: False # Underflow bin normalized with binwidth
+  last_bin_center: 1500
+  first_bin_center: 45
+  plot_log: 1
+  variable: "m_{jj}"
+  y_unit: "(fb/GeV)"
+  x_unit: "(GeV)"
+  x_lim: [0, 1500]
+  y_lim: [-1,3]
+  y_lim_top: 500
+  overflow: 1500

--- a/config/2023_MassJ0J1.yml
+++ b/config/2023_MassJ0J1.yml
@@ -1,0 +1,248 @@
+# Config file: options for signal fitting
+
+outputFolder: '/net/data_cms3a-1/daumann/PhD/Final_fits_repo/CMSSW_14_1_0_pre4/src/flashggFinalFit_hig19016_MassJ0J1/output_2023_MassJ0J1_new_binning/'
+
+inputFiles:
+  # Trees2WS
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2023/data/allData_2023.root'
+  Trees2WS: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2023/signal/'
+
+backgroundScriptCfg:
+  # Setup
+  cats: 'auto' # auto: automatically inferred from input ws
+  catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
+  ext: 'Run3FidXSAnalysis_MassJ0J1' # extension to add to output directory
+  # year: '2023' # Use combined when merging all years in category (for plots)
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+trees2wsCfg:
+  inputTreeDir: 'DiphotonTree' # Name of RooDirectory storing input tree
+
+  apply_mass_cut: False # Apply cut on CMS_hgg_mass
+  mass_cut_range: '100,180' # CMS_hgg_mass cut range
+  doSTXSSplitting: False # Split output WS per STXS bin
+  doDiffSplitting: True # Split output WS per differential bin
+  doInOutSplitting: False # Split output WS into in/out fiducial based on some variable in the input trees (to be improved).
+  doSystematics: True # Add systematics datasets to output WS
+
+  # Variables to be added to dataframe: use wildcard * for common strings
+  mainVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "weight_central"
+    - "dZ"
+    - "*Up"
+    - "*Down"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  dataVars:
+    - "CMS_hgg_mass"
+    - "weight" # Vars to be added for data
+
+  stxsVar: ''
+  diffVar: 'diffVariable_GenMassJ0J1'
+  notagVars: [] # Vars to add to NOTAG RooDataset
+
+  systematicsVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  theoryWeightContainers:
+    weight_LHEPdf: 101
+    weight_LHEScale: 9
+
+  # List of systematics: use string YEAR for year-dependent systematics
+  systematics:
+    - "ScaleEBZmmg"
+    - "ScaleEEZmmg"
+    - "ScaleEBZee"
+    - "ScaleEEZee"
+    - "Smearing"
+    - "energyErrShift"
+    - "JerSyst"
+    - "JecSystTotal"
+
+  cats: 'auto'
+
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2023_preBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2023preBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2023preBPix' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '10'
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.703'
+  beamspotWidthMC: '3.597'
+
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2023_postBPix:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2023postBPix' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2023postBPix' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '10'
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.737'
+  beamspotWidthMC: '3.597'
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+packaged_2023:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  mergeYears: True # Merges the eras
+  ext: ''
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+datacard_yields:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  procs: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis' # Extension for saving
+  # inputWSDirMap: '2023preBPix,2023postBPix'
+  sigModelWSDir: './Models_MassJ0J1/signal' # Input signal model WS directory
+  bkgModelWSDir: './Models_MassJ0J1/background' # Input background model WS directory
+  bkgModelExt: 'multipdf' # Extension used when saving background model
+  doSystematics: True # Include systematics calculations and add to datacard
+  mergeYears: True # Merge category across years
+  skipZeroes: True # Skip signal processes with 0 sum of weights
+  ignore_warnings: True # Skip errors for missing systematics. Instead output warning message
+  mass: '125' # Input workspace mass
+  skipBkg: False # Only add signal processes to datacard
+  bkgScaler: 1. # Add overall scale factor for background
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 16000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+datacard:
+  # For pruning processes
+  prune: True # Prune proc x cat which make up less than pruneThreshold (default 0.1%) of given total category
+  pruneThreshold: 0.001 # Threshold with which to prune proc x cat as fraction of total category yield (default=0.1%)
+  doTrueYield: True # For pruning: use true number of expected events for proc x cat i.e. Product(XS,BR,eff*acc,lumi). If false then will use nominal_yield (i.e. sumEntries)
+  analysis: 'Run3FidXSAnalysis' # Analysis extension: required for doTrueYield (see ./tools/XSBR.py for example)
+
+  # For yield/systematics:
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance
+  doSystematics: True # Include systematics calculations and add to datacard
+  doMCStatUncertainty: True # Add uncertainty for MC stats
+  doSTXSMerging: False # Calculate additional migrations uncertainties for merged STXS bins (for 'mnorm' tier in systematics)
+  doSTXSScaleCorrelationScheme: False # Partially de-correlate scale uncertainties for different phase space regions
+
+  # For output:
+  saveDataFrame: False # Save final dataframe as pkl file
+  output: 'Datacard_MassJ0J1_2023' # Datacard name
+
+datacard_clean:
+  factor: 10000 # Factor beyond which uncertainty is considered incorrect and is removed
+  removeDoubleSided: False # Remove any nuisances which are listed as antisymmetric but both values point the same way
+  removeNonDiagonal: False # Remove any nuisances which are affect processes unimportant in that category
+  symmetrizeNuisance: 'CMS_hgg_SigmaEOverEShift,CMS_hgg_scale_0_shape,CMS_hgg_scale_1_shape,CMS_hgg_scale_3_shape' # Symmetrizes asymmetric nuisance. Enter in the format nuisance1,nuisance2,nuisance3,etc.
+  verbose: False # Spit out all the cleaning being done
+
+combine_fit:
+  asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
+  unblindedFit_numPoints: 100
+  setParameterRange: "r=-1,3"
+  cminApproxPreFitTolerance: 0.01
+  rMin: 0
+  rMax: 2
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_impacts:
+  exclude: "" # Nuisances that should be excluded from the impact computation
+  cminApproxPreFitTolerance: 0.01
+  setParameters: 1.000
+  stepSize: 0.05
+  setCrossingTolerance: 0.00005
+  not_show_POI: True
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_hesse:
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_mggToys:
+  nToys: 1000 # Number of toys = nToys * 10
+  loadSnapshot: 'MultiDimFit'
+  doBands: True
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+spectra:
+  no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
+  ggh_xs: "fidXS_MassJ0J1_ggH"
+  vbf_xs: "fidXS_MassJ0J1_VBFH"
+  vh_xs: "fidXS_MassJ0J1_VH"
+  tth_xs: "fidXS_MassJ0J1_ttH"
+  xh_xs: "fidXS_MassJ0J1_xH"
+  ggh_powheg_xs: "fidXS_MassJ0J1_ggH_powheg"
+  ggh_no_nnlops_xs: "fidXS_MassJ0J1_ggH_genWeight"
+  underflow_bin_normalized: False # Underflow bin normalized with binwidth
+  last_bin_center: 1500
+  first_bin_center: 45
+  plot_log: 1
+  variable: "m_{jj}"
+  y_unit: "(fb/GeV)"
+  x_unit: "(GeV)"
+  x_lim: [0, 1500]
+  y_lim: [-1,3]
+  y_lim_top: 500
+  overflow: 1500

--- a/config/2024_MassJ0J1.yml
+++ b/config/2024_MassJ0J1.yml
@@ -1,0 +1,219 @@
+# Config file: options for signal fitting
+
+outputFolder: '/net/data_cms3a-1/daumann/PhD/Final_fits_repo/CMSSW_14_1_0_pre4/src/flashggFinalFit_hig19016_MassJ0J1/output_2024_MassJ0J1_new_binning/'
+
+inputFiles:
+  # Trees2WS
+  Trees2WSData: '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2024/data/allData_2024.root'
+  Trees2WS:     '/net/data_cms3a-2/nobackup/group_JE_CMS/Hgg_PartialRun3/stat_analysis/differential/2026_27_08/Mjj_hig_19_016_binning/2024/signal/'
+
+backgroundScriptCfg:
+  # Setup
+  cats: 'auto' # auto: automatically inferred from input ws
+  catOffset: 0 # add offset to category numbers (useful for categories from different allData.root files)
+  ext: 'Run3FidXSAnalysis_MassJ0J1' # extension to add to output directory
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 12000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+trees2wsCfg:
+  inputTreeDir: 'DiphotonTree' # Name of RooDirectory storing input tree
+
+  apply_mass_cut: False # Apply cut on CMS_hgg_mass
+  mass_cut_range: '100,180' # CMS_hgg_mass cut range
+  doSTXSSplitting: False # Split output WS per STXS bin
+  doDiffSplitting: True # Split output WS per differential bin
+  doInOutSplitting: False # Split output WS into in/out fiducial based on some variable in the input trees (to be improved).
+  doSystematics: True # Add systematics datasets to output WS
+
+  # Variables to be added to dataframe: use wildcard * for common strings
+  mainVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "weight_central"
+    - "dZ"
+    - "*Up"
+    - "*Down"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  dataVars:
+    - "CMS_hgg_mass"
+    - "weight" # Vars to be added for data
+
+  stxsVar: ''
+  diffVar: 'diffVariable_GenMassJ0J1'
+  notagVars: [] # Vars to add to NOTAG RooDataset
+
+  systematicsVars:
+    - "CMS_hgg_mass"
+    - "weight"
+    - "fiducialGeometricFlag"
+    - "diffVariable_GenMassJ0J1"
+
+  theoryWeightContainers:
+    weight_LHEPdf: 101
+    weight_LHEScale: 9
+
+  # List of systematics: use string YEAR for year-dependent systematics
+  systematics:
+    - "ScaleEBZmmg"
+    - "ScaleEEZmmg"
+    - "ScaleEBZee"
+    - "ScaleEEZee"
+    - "Smearing"
+    - "energyErrShift"
+    - "JerSyst"
+    - "JecSystTotal"
+
+  cats: 'auto'
+
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 34000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+signalScriptCfg_2024:
+  # Setup
+  procs: 'auto' # if auto: inferred automatically from filenames (requires names to be of form *pythia8_{PROC}.root)
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis_MassJ0J1_2024' # output directory extension
+  analysisRM: 'Run3FidXSAnalysisMassJ0J1' # To specify replacement dataset (defined in ./commonTools/replacementMap.py)
+  analysisXSBR: 'Run3FidXSAnalysis' # To specify XSBR dataset (defined in ./commonTools/XSBRMap.py)
+  year: '2024' # Use 'combined' if merging all years: not recommended
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  replacementThreshold: '10'
+  # Photon shape systematics
+  scales: 'ScaleEEZee,ScaleEBZee' # separate nuisance per year
+  scalesCorr: 'ScaleEEZmmg,ScaleEBZmmg' # correlated across years
+  scalesGlobal: '' # affect all processes equally, correlated across years
+  smears: 'Smearing' # separate nuisance per year
+
+  doPlots: True
+
+  beamspotWidthData: '3.583'
+  beamspotWidthMC: '3.601'
+
+
+  # Job submission options
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 34000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+packaged_2024:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  massPoints: '120,125,130' # You can now run with a single mass point if necessary
+  mergeYears: True # Merges the eras
+  ext: ''
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 34000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+datacard_yields:
+  cats: 'auto' # if auto: inferred automatically from (0) workspace
+  procs: 'auto' # if auto: inferred automatically from (0) workspace
+  ext: 'Run3FidXSAnalysis' # Extension for saving
+  sigModelWSDir: './Models_MassJ0J1/signal' # Input signal model WS directory
+  bkgModelWSDir: './Models_MassJ0J1/background' # Input background model WS directory
+  bkgModelExt: 'multipdf' # Extension used when saving background model
+  doSystematics: True # Include systematics calculations and add to datacard
+  mergeYears: True # Merge category across years
+  skipZeroes: True # Skip signal processes with 0 sum of weights
+  ignore_warnings: True # Skip errors for missing systematics. Instead output warning message
+  mass: '125' # Input workspace mass
+  skipBkg: False # Only add signal processes to datacard
+  bkgScaler: 1. # Add overall scale factor for background
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance. Use if no centralObjectWeight in workspace
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 12000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+datacard:
+  # For pruning processes
+  prune: True # Prune proc x cat which make up less than pruneThreshold (default 0.1%) of given total category
+  pruneThreshold: 0.001 # Threshold with which to prune proc x cat as fraction of total category yield (default=0.1%)
+  doTrueYield: True # For pruning: use true number of expected events for proc x cat i.e. Product(XS,BR,eff*acc,lumi). If false then will use nominal_yield (i.e. sumEntries)
+  analysis: 'Run3FidXSAnalysis' # Analysis extension: required for doTrueYield (see ./tools/XSBR.py for example)
+
+  # For yield/systematics:
+  skipCOWCorr: True # Skip centralObjectWeight correction for events in acceptance
+  doSystematics: True # Include systematics calculations and add to datacard
+  doMCStatUncertainty: True # Add uncertainty for MC stats
+  doSTXSMerging: False # Calculate additional migrations uncertainties for merged STXS bins (for 'mnorm' tier in systematics)
+  doSTXSScaleCorrelationScheme: False # Partially de-correlate scale uncertainties for different phase space regions
+
+  # For output:
+  saveDataFrame: False # Save final dataframe as pkl file
+  output: 'Datacard_MassJ0J1_2024' # Datacard name
+
+datacard_clean:
+  factor: 10000 # Factor beyond which uncertainty is considered incorrect and is removed
+  removeDoubleSided: False # Remove any nuisances which are listed as antisymmetric but both values point the same way
+  removeNonDiagonal: False # Remove any nuisances which are affect processes unimportant in that category
+  symmetrizeNuisance: 'CMS_hgg_SigmaEOverEShift,CMS_hgg_scale_0_shape,CMS_hgg_scale_1_shape,CMS_hgg_scale_3_shape' # Symmetrizes asymmetric nuisance. Enter in the format nuisance1,nuisance2,nuisance3,etc.
+  verbose: False # Spit out all the cleaning being done
+
+combine_fit:
+  asimov_numPoints: 30 # Number of points the Asimov generator should generate for the NLL scan
+  unblindedFit_numPoints: 100
+  setParameterRange: "r=-1,3"
+  cminApproxPreFitTolerance: 0.01
+  rMin: 0
+  rMax: 2
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_impacts:
+  exclude: "" # Nuisances that should be excluded from the impact computation
+  cminApproxPreFitTolerance: 0.01
+  setParameters: 1.000
+  stepSize: 0.05
+  setCrossingTolerance: 0.00005
+  not_show_POI: True
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_hesse:
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+combine_mggToys:
+  nToys: 1000 # Number of toys = nToys * 10
+  loadSnapshot: 'MultiDimFit'
+  doBands: True
+  execution: 'htcondor'
+  batchPartition: "short" # Slurm partition to use for job submission
+  batchMemory: 4000 # Slurm memory to use for job submission
+  batchMaxRuntime: "01:00:00" # Slurm max runtime to use
+
+spectra:
+  no_preliminary: True # Flag that determines, if Preliminary label should be printed.
+  private_work : False
+  ggh_xs: "fidXS_MassJ0J1_ggH"
+  vbf_xs: "fidXS_MassJ0J1_VBFH"
+  vh_xs: "fidXS_MassJ0J1_VH"
+  tth_xs: "fidXS_MassJ0J1_ttH"
+  xh_xs: "fidXS_MassJ0J1_xH"
+  ggh_powheg_xs: "fidXS_MassJ0J1_ggH_powheg"
+  ggh_no_nnlops_xs: "fidXS_MassJ0J1_ggH_genWeight"
+  underflow_bin_normalized: False # Underflow bin normalized with binwidth
+  last_bin_center: 1500
+  first_bin_center: 45
+  plot_log: 1
+  variable: "m_{jj}"
+  y_unit: "(fb/GeV)"
+  x_unit: "(GeV)"
+  x_lim: [0, 1500]
+  y_lim: [-1,3]
+  y_lim_top: 500
+  overflow: 1500

--- a/law/htcondor_setup.sh
+++ b/law/htcondor_setup.sh
@@ -2,23 +2,31 @@
 
 action() {
 
-    cd /net/data_cms3a-1/spaeh/private/PhD/analyses/partial_Run3_differential/Hgg-PartialRun3-3A-ETH-Analysis/fitting/CMSSW_14_1_0_pre4/src/flashggFinalFit/
-    export ANALYSIS_PATH="$(pwd)"
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
+    local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    local script_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
+    local this_dir="$( cd "${script_dir}/.." && pwd )"
+
+    cd "${this_dir}" || return 1
+    export ANALYSIS_PATH="${this_dir}"
     # The following source of cmsset_default.sh is needed on architectures other than lxplus, when the default cms commands are not sourced at startup
     export VO_CMS_SW_DIR="/cvmfs/cms.cern.ch"
     source $VO_CMS_SW_DIR/cmsset_default.sh
     cmsenv
-    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
-    local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
-    local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
-
-    if [ ! -d "${PWD}/law/install_dir" ] || [ -z "$(ls -A "${PWD}/law/install_dir")" ]; then
-        PYTHONUSERBASE="${PWD}/law/install_dir" pip3 install --user --no-cache-dir --force-reinstall "git+https://github.com/riga/law.git@master"
+    local install_dir="${this_dir}/law/install_dir"
+    local shared_install_dir="$( dirname "${this_dir}" )/flashggFinalFit/law/install_dir"
+    if [ ! -d "${install_dir}" ] || [ -z "$(ls -A "${install_dir}" 2>/dev/null)" ]; then
+        if [ -d "${shared_install_dir}" ] && [ -n "$(ls -A "${shared_install_dir}" 2>/dev/null)" ]; then
+            install_dir="${shared_install_dir}"
+            echo "Using shared law installation at ${install_dir}"
+        else
+            PYTHONUSERBASE="${install_dir}" pip3 install --user --no-cache-dir --force-reinstall "git+https://github.com/riga/law.git@master"
+        fi
     else
-        echo "Directory ${PWD}/law/install_dir already exists and is not empty. Using local law installation..."
+        echo "Directory ${install_dir} already exists and is not empty. Using local law installation..."
     fi
 
-    export INSTALL_DIR="${PWD}/law/install_dir"
+    export INSTALL_DIR="${install_dir}"
     export PYTHONPATH="${PYTHONPATH}:${INSTALL_DIR}/lib/python3.9/site-packages"
     export PATH="${INSTALL_DIR}/bin:${PATH}"
 


### PR DESCRIPTION
## Summary

This MR implements the new `MassJ0J1` differential binning on top of the `hig-19-016-binning` branch.

## New binning

- `Njets < 2` underflow bin
- `0–75 GeV`
- `75–120 GeV`
- `120–180 GeV`
- `180–300 GeV`
- `300–500 GeV`
- `500–1000 GeV`
- `1000–10000 GeV`
- Out-of-fiducial bin
